### PR TITLE
feat(scripts): Google Sheets access checklist + test script

### DIFF
--- a/docs/google-sheets-access.md
+++ b/docs/google-sheets-access.md
@@ -1,0 +1,46 @@
+# Google Sheets access setup
+
+The `google-sheets` package reads a private spreadsheet via the Sheets API v4
+using a Google Cloud **service account**. Code alone is not enough — the
+following human steps must be completed in the Google Cloud console, and the
+target spreadsheet must be shared with the service account before any read will
+succeed.
+
+Target spreadsheet:
+`https://docs.google.com/spreadsheets/d/1z72xbr5QMxGOAHYKL5rqRUVtLoVvmGNkceUqX5xgS7w/edit?gid=550756003`
+
+## Operator checklist
+
+1. - [ ] Create or select a Google Cloud project at
+   <https://console.cloud.google.com/>.
+2. - [ ] Enable the **Google Sheets API** for that project
+   (APIs & Services → Library → "Google Sheets API" → Enable).
+3. - [ ] Create a **service account** (IAM & Admin → Service Accounts → Create),
+   then generate a **JSON key** for it (Keys → Add Key → Create new key → JSON)
+   and download the key file. Note the service-account email (the
+   auto-generated address ending in `.iam` for that project).
+4. - [ ] Share the target spreadsheet — paste this URL —
+   `https://docs.google.com/spreadsheets/d/1z72xbr5QMxGOAHYKL5rqRUVtLoVvmGNkceUqX5xgS7w/edit?gid=550756003`
+   with the service-account email as **Viewer**.
+5. - [ ] Set credentials via environment variables, using **exactly one** of the
+   two supported shapes:
+   - `GOOGLE_APPLICATION_CREDENTIALS` — absolute path to the downloaded
+     service-account JSON key file, **or**
+   - both `GOOGLE_SERVICE_ACCOUNT_EMAIL` (the service-account email) and
+     `GOOGLE_PRIVATE_KEY` (the inline PEM private key from the JSON key).
+
+> **`GOOGLE_PRIVATE_KEY` newline note:** in `.env`, the PEM value must be kept
+> on a single line with its newlines escaped as literal `\n`. The package
+> un-escapes `\n` back into real newlines at load time.
+
+## Verify
+
+Once the steps above are complete, run:
+
+```bash
+bun run test:sheet-access
+```
+
+It lists the spreadsheet's tab titles, resolves the target tab by `gid`, and
+prints the first five rows of that tab. With no valid credentials it fails fast
+with a readable error and a non-zero exit code.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pghbeer",
   "type": "module",
   "private": true,
+  "dependencies": {
+    "google-sheets": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "concurrently": "^9.1.2",
@@ -30,6 +33,7 @@
     "db:migrate": "source .env && bun run --cwd packages/database migrate",
     "db:pull": "source .env && bun run --cwd packages/database pull",
     "import": "bun run scripts/import.ts",
+    "test:sheet-access": "bun run scripts/test-sheet-access.ts",
     "deploy:api": "fly deploy --config ./deploy/api/fly.toml --dockerfile ./deploy/api/Dockerfile",
     "deploy:www": "fly deploy --config ./deploy/www/fly.toml --dockerfile ./deploy/www/Dockerfile",
     "sync-secrets:api": "./scripts/sync-fly-secrets.sh apps/api pghbeer-api",

--- a/scripts/test-sheet-access.ts
+++ b/scripts/test-sheet-access.ts
@@ -1,0 +1,59 @@
+import {listSheetTitles, readSheetValues, getAccessToken} from 'google-sheets';
+
+const SPREADSHEET_ID = '1z72xbr5QMxGOAHYKL5rqRUVtLoVvmGNkceUqX5xgS7w';
+const TARGET_GID = 550756003;
+
+const SHEETS_API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets';
+
+type SheetsPropertiesResponse = {
+  sheets?: Array<{properties?: {title?: string; sheetId?: number}}>;
+};
+
+/**
+ * Resolve a tab's title from its gid (`sheetId`). `listSheetTitles` only
+ * requests `sheets.properties.title`, so it cannot map gid -> title; fetch the
+ * `sheetId` alongside the title directly via the already-minted access token.
+ */
+async function resolveTitleForGid(gid: number): Promise<string> {
+  const token = await getAccessToken();
+  const res = await fetch(
+    `${SHEETS_API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties(title,sheetId)`,
+    {headers: {Authorization: `Bearer ${token}`}},
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Sheets spreadsheets.get for ${SPREADSHEET_ID} failed (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as SheetsPropertiesResponse;
+  const match = (data.sheets ?? []).find((sheet) => sheet.properties?.sheetId === gid);
+  const title = match?.properties?.title;
+
+  if (!title) {
+    throw new Error(`tab gid ${gid} not found in spreadsheet ${SPREADSHEET_ID}`);
+  }
+
+  return title;
+}
+
+async function main() {
+  const titles = await listSheetTitles({spreadsheetId: SPREADSHEET_ID});
+  console.log(`Tabs (${titles.length}): ${titles.join(', ')}`);
+
+  const title = await resolveTitleForGid(TARGET_GID);
+  console.log(`Target tab gid ${TARGET_GID} -> "${title}"`);
+
+  const rows = await readSheetValues({spreadsheetId: SPREADSHEET_ID, range: `${title}!1:5`});
+  console.log(`First ${rows.length} rows of "${title}":`);
+  for (const row of rows) {
+    console.log(row.join(' | '));
+  }
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('test:sheet-access failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds operator-facing documentation and a runnable end-to-end test for the `google-sheets` package (from #12), so an operator can verify that a local script can authenticate and read the private festival-form sheet.

- **`docs/google-sheets-access.md`** — numbered `- [ ]` checklist of the human Google Cloud steps (create project, enable Sheets API, create service account + JSON key, share the target spreadsheet as Viewer, set credentials). Names the exact env vars (`GOOGLE_APPLICATION_CREDENTIALS` **or** `GOOGLE_SERVICE_ACCOUNT_EMAIL` + `GOOGLE_PRIVATE_KEY`) and the `\n`-escaping note for the inline PEM.
- **`scripts/test-sheet-access.ts`** — mirrors `scripts/import.ts` style. Lists tab titles, resolves the target `gid` (550756003) → title via the exported `getAccessToken` + a single native `fetch` to the `?fields=sheets.properties(title,sheetId)` endpoint (since `listSheetTitles` doesn't expose `sheetId`), then reads `1:5` of that tab. Fails fast with a readable error + non-zero exit on missing env or API error; never prints credentials.
- **Root `package.json`** — declares `google-sheets` as a `workspace:*` dependency and adds the `test:sheet-access` script.

## Verification

- `bun run typecheck` exits 0.
- `bun run scripts/test-sheet-access.ts` with no credentials exits 1 with the `Invalid environment variables: ...` message (not an uncaught stack trace).
- No credential literals committed.

A live 200 is not part of this PR — completing the GCP console steps and sharing the sheet is the operator's job, documented in the checklist.

## Notes

- `bun.lock` is gitignored in this repo, so the new workspace edge is not committed; `bun install` regenerates it and reflects the edge locally.
- The package source is untouched — gid resolution uses only public exports plus a direct fetch, per the task's no-scope-creep constraint.