### PR TITLE
feat(www): add /admin shell with nav, primitives, and server-fn

### DIFF
--- a/apps/www/src/components/admin/ConfirmDelete.tsx
+++ b/apps/www/src/components/admin/ConfirmDelete.tsx
@@ -1,3 +1,5 @@
+import {useId} from 'react';
+
 export type ConfirmDeleteProps = {
   open: boolean;
   title?: string;
@@ -8,16 +10,21 @@ export type ConfirmDeleteProps = {
   confirming?: boolean;
 };
 
+// Naive singular form for the entity names this admin manages (beers, events,
+// breweries, styles). Handles the "-ies" plural so "breweries" -> "brewery".
+function singularize(name: string): string {
+  if (name.endsWith('ies')) return `${name.slice(0, -3)}y`;
+  if (name.endsWith('s')) return name.slice(0, -1);
+  return name;
+}
+
 // Pure, exported for unit testing. Renders dependent counts as human text, e.g.
 // {beers: 3, events: 1} -> "used by 3 beers and 1 event". Zero counts are
 // omitted. Returns '' when nothing depends on the entity.
 export function formatDependents(dependents: Record<string, number>): string {
   const parts = Object.entries(dependents)
     .filter(([, count]) => count > 0)
-    .map(([name, count]) => {
-      const singular = name.endsWith('s') ? name.slice(0, -1) : name;
-      return `${count} ${count === 1 ? singular : name}`;
-    });
+    .map(([name, count]) => `${count} ${count === 1 ? singularize(name) : name}`);
 
   if (parts.length === 0) return '';
 
@@ -38,6 +45,8 @@ export function ConfirmDelete({
   onCancel,
   confirming = false,
 }: ConfirmDeleteProps) {
+  const titleId = useId();
+
   if (!open) return null;
 
   const blockedText =
@@ -47,9 +56,20 @@ export function ConfirmDelete({
   const blocked = blockedText !== '';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4">
-      <div className="w-full max-w-sm rounded-xl border border-border bg-surface p-6 shadow-lg">
-        <h2 className="font-display text-lg font-bold text-text">{title}</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div
+        className="w-full max-w-sm rounded-xl border border-border bg-surface p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="font-display text-lg font-bold text-text">
+          {title}
+        </h2>
         <p className="mt-2 text-sm text-text-secondary">
           {blocked ? `Can't delete — ${blockedText}.` : message}
         </p>

--- a/apps/www/src/components/admin/ConfirmDelete.tsx
+++ b/apps/www/src/components/admin/ConfirmDelete.tsx
@@ -1,0 +1,78 @@
+export type ConfirmDeleteProps = {
+  open: boolean;
+  title?: string;
+  message?: string;
+  dependents?: Record<string, number>;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirming?: boolean;
+};
+
+// Pure, exported for unit testing. Renders dependent counts as human text, e.g.
+// {beers: 3, events: 1} -> "used by 3 beers and 1 event". Zero counts are
+// omitted. Returns '' when nothing depends on the entity.
+export function formatDependents(dependents: Record<string, number>): string {
+  const parts = Object.entries(dependents)
+    .filter(([, count]) => count > 0)
+    .map(([name, count]) => {
+      const singular = name.endsWith('s') ? name.slice(0, -1) : name;
+      return `${count} ${count === 1 ? singular : name}`;
+    });
+
+  if (parts.length === 0) return '';
+
+  const joined =
+    parts.length === 1
+      ? parts[0]
+      : `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+
+  return `used by ${joined}`;
+}
+
+export function ConfirmDelete({
+  open,
+  title = 'Delete this item?',
+  message = 'This action cannot be undone.',
+  dependents,
+  onConfirm,
+  onCancel,
+  confirming = false,
+}: ConfirmDeleteProps) {
+  if (!open) return null;
+
+  const blockedText =
+    dependents && Object.values(dependents).some((count) => count > 0)
+      ? formatDependents(dependents)
+      : '';
+  const blocked = blockedText !== '';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-surface p-6 shadow-lg">
+        <h2 className="font-display text-lg font-bold text-text">{title}</h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          {blocked ? `Can't delete — ${blockedText}.` : message}
+        </p>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-border bg-surface px-4 py-2 text-sm text-text-secondary hover:text-text"
+          >
+            {blocked ? 'Close' : 'Cancel'}
+          </button>
+          {blocked ? null : (
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={confirming}
+              className="rounded-lg bg-red px-4 py-2 text-sm font-semibold text-check-fg disabled:opacity-60"
+            >
+              {confirming ? 'Deleting…' : 'Delete'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/components/admin/DataTable.tsx
+++ b/apps/www/src/components/admin/DataTable.tsx
@@ -1,0 +1,140 @@
+import {useId, useMemo, useState} from 'react';
+import type {ReactNode} from 'react';
+
+export type Column<Row> = {
+  id: string;
+  header: string;
+  accessor: (row: Row) => string | number | boolean | null | undefined;
+  cell?: (row: Row) => ReactNode;
+};
+
+export type RowAction<Row> = {
+  label: string;
+  onClick: (row: Row) => void;
+  variant?: 'default' | 'danger';
+};
+
+export type DataTableProps<Row> = {
+  columns: Column<Row>[];
+  rows: Row[];
+  getRowId: (row: Row) => string | number;
+  actions?: (row: Row) => RowAction<Row>[];
+  filterPlaceholder?: string;
+  emptyMessage?: string;
+};
+
+// Pure, exported for unit testing without a DOM harness. Returns rows where any
+// column's stringified accessor value contains the (case-insensitive) query.
+// Empty / whitespace-only queries pass every row through.
+export function filterRows<Row>(
+  rows: Row[],
+  columns: Column<Row>[],
+  query: string,
+): Row[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') return rows;
+
+  return rows.filter((row) =>
+    columns.some((column) =>
+      String(column.accessor(row) ?? '')
+        .toLowerCase()
+        .includes(needle),
+    ),
+  );
+}
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  getRowId,
+  actions,
+  filterPlaceholder,
+  emptyMessage = 'Nothing here yet.',
+}: DataTableProps<Row>) {
+  const filterId = useId();
+  const [query, setQuery] = useState('');
+
+  const visibleRows = useMemo(
+    () => filterRows(rows, columns, query),
+    [rows, columns, query],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <label htmlFor={filterId} className="sr-only">
+          Filter
+        </label>
+        <input
+          id={filterId}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={filterPlaceholder ?? 'Filter…'}
+          className="w-full max-w-xs rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-muted"
+        />
+      </div>
+
+      {visibleRows.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface px-4 py-8 text-center text-sm text-text-secondary">
+          {emptyMessage}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border bg-surface-alt text-left">
+                {columns.map((column) => (
+                  <th
+                    key={column.id}
+                    className="px-4 py-2.5 font-semibold text-text-secondary"
+                  >
+                    {column.header}
+                  </th>
+                ))}
+                {actions ? (
+                  <th className="px-4 py-2.5 font-semibold text-text-secondary">
+                    Actions
+                  </th>
+                ) : null}
+              </tr>
+            </thead>
+            <tbody>
+              {visibleRows.map((row) => (
+                <tr
+                  key={getRowId(row)}
+                  className="border-b border-border-light bg-surface last:border-b-0"
+                >
+                  {columns.map((column) => (
+                    <td key={column.id} className="px-4 py-2.5 text-text">
+                      {column.cell ? column.cell(row) : column.accessor(row)}
+                    </td>
+                  ))}
+                  {actions ? (
+                    <td className="px-4 py-2.5">
+                      <div className="flex gap-2">
+                        {actions(row).map((action) => (
+                          <button
+                            key={action.label}
+                            onClick={() => action.onClick(row)}
+                            className={
+                              action.variant === 'danger'
+                                ? 'rounded-md px-2 py-1 text-xs font-medium text-red hover:underline'
+                                : 'rounded-md px-2 py-1 text-xs font-medium text-text-secondary hover:text-text hover:underline'
+                            }
+                          >
+                            {action.label}
+                          </button>
+                        ))}
+                      </div>
+                    </td>
+                  ) : null}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/www/src/components/admin/EntityForm.tsx
+++ b/apps/www/src/components/admin/EntityForm.tsx
@@ -1,0 +1,167 @@
+import {useId} from 'react';
+import type {FormEvent} from 'react';
+
+type FieldBase = {
+  name: string;
+  label: string;
+  required?: boolean;
+};
+
+export type SelectOption = {value: string | number; label: string};
+
+export type FieldDef =
+  | (FieldBase & {type: 'text'})
+  | (FieldBase & {type: 'number'})
+  | (FieldBase & {type: 'checkbox'})
+  | (FieldBase & {type: 'select'; options: SelectOption[]});
+
+export type FieldValue = string | number | boolean | null | undefined;
+
+export type EntityFormProps = {
+  fields: FieldDef[];
+  values: Record<string, FieldValue>;
+  onChange: (name: string, value: FieldValue) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  submitLabel?: string;
+  as?: 'modal' | 'inline';
+};
+
+export function EntityForm({
+  fields,
+  values,
+  onChange,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save',
+  as = 'modal',
+}: EntityFormProps) {
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    onSubmit();
+  }
+
+  const form = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {fields.map((field) => (
+        <Field
+          key={field.name}
+          field={field}
+          value={values[field.name]}
+          onChange={onChange}
+        />
+      ))}
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-border bg-surface px-4 py-2 text-sm text-text-secondary hover:text-text"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-check-fg"
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+
+  if (as === 'inline') {
+    return form;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4">
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-lg">
+        {form}
+      </div>
+    </div>
+  );
+}
+
+type FieldProps = {
+  field: FieldDef;
+  value: FieldValue;
+  onChange: (name: string, value: FieldValue) => void;
+};
+
+function Field({field, value, onChange}: FieldProps) {
+  const id = useId();
+  const labelText = (
+    <label htmlFor={id} className="text-sm font-medium text-text">
+      {field.label}
+      {field.required ? <span className="text-red"> *</span> : null}
+    </label>
+  );
+  const inputClass =
+    'rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-muted';
+
+  switch (field.type) {
+    case 'text':
+      return (
+        <div className="flex flex-col gap-1.5">
+          {labelText}
+          <input
+            id={id}
+            type="text"
+            required={field.required}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(field.name, e.target.value)}
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'number':
+      return (
+        <div className="flex flex-col gap-1.5">
+          {labelText}
+          <input
+            id={id}
+            type="number"
+            required={field.required}
+            value={value === null || value === undefined ? '' : Number(value)}
+            onChange={(e) =>
+              onChange(field.name, e.target.value === '' ? null : Number(e.target.value))
+            }
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'checkbox':
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            id={id}
+            type="checkbox"
+            checked={value === true}
+            onChange={(e) => onChange(field.name, e.target.checked)}
+            className="h-4 w-4"
+          />
+          {labelText}
+        </div>
+      );
+    case 'select':
+      return (
+        <div className="flex flex-col gap-1.5">
+          {labelText}
+          <select
+            id={id}
+            required={field.required}
+            value={value === null || value === undefined ? '' : String(value)}
+            onChange={(e) => onChange(field.name, e.target.value)}
+            className={inputClass}
+          >
+            <option value="">—</option>
+            {field.options.map((option) => (
+              <option key={option.value} value={String(option.value)}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      );
+  }
+}

--- a/apps/www/src/components/admin/EntityForm.tsx
+++ b/apps/www/src/components/admin/EntityForm.tsx
@@ -74,7 +74,11 @@ export function EntityForm({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      role="dialog"
+      aria-modal="true"
+    >
       <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-lg">
         {form}
       </div>

--- a/apps/www/src/components/admin/nav.ts
+++ b/apps/www/src/components/admin/nav.ts
@@ -1,0 +1,17 @@
+// Single source of truth for the admin left rail.
+// Entity tasks must NOT edit this array — their routes 404 until their task
+// lands. Adding a route file is enough; the nav entry already exists here.
+
+export type NavItem = {
+  label: string;
+  to: string;
+  exact?: boolean;
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  {label: 'Dashboard', to: '/admin', exact: true},
+  {label: 'Breweries', to: '/admin/breweries'},
+  {label: 'Styles', to: '/admin/styles'},
+  {label: 'Beers', to: '/admin/beers'},
+  {label: 'Events', to: '/admin/events'},
+];

--- a/apps/www/src/lib/admin/server-fn.ts
+++ b/apps/www/src/lib/admin/server-fn.ts
@@ -1,0 +1,50 @@
+// SERVER-ONLY module. This file reads the admin API key from process.env and
+// must never be imported into client code. It deliberately does NOT import
+// lib/constants.ts (which exposes keys via import.meta.env client-side).
+//
+// Convention — each entity adds its OWN lib/admin/<entity>.ts, e.g.:
+//   import {createServerFn} from '@tanstack/react-start';
+//   import {adminFetch} from './server-fn';
+//   export const listBreweries = createServerFn({method: 'GET'})
+//     .handler(async () => (await adminFetch('/admin/breweries')).json());
+// adminFetch only runs inside createServerFn handlers, so ADMIN_API_KEY stays
+// server-side and is never bundled to the client. There is no shared client
+// file — each entity wraps its own calls.
+
+function resolveBaseUrl(): string {
+  return (
+    process.env.API_URL ?? process.env.VITE_API_URL ?? 'http://localhost:3001'
+  );
+}
+
+function resolveApiKey(): string {
+  return process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? '';
+}
+
+export async function adminFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const url = `${resolveBaseUrl()}${path}`;
+  const key = resolveApiKey();
+
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+      ...init.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(
+      `Admin API request failed: ${res.status} ${res.statusText} for ${path}${
+        body ? ` — ${body}` : ''
+      }`,
+    );
+  }
+
+  return res;
+}

--- a/apps/www/src/routes/admin/index.tsx
+++ b/apps/www/src/routes/admin/index.tsx
@@ -1,0 +1,19 @@
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/admin/')({
+  head: () => ({
+    meta: [{title: 'PghBeer — Admin'}],
+  }),
+  component: AdminDashboard,
+});
+
+function AdminDashboard() {
+  return (
+    <div>
+      <h1 className="font-display text-2xl font-bold text-gold">Admin</h1>
+      <p className="mt-2 text-sm text-text-secondary">
+        Pick an entity from the left rail to manage festival data.
+      </p>
+    </div>
+  );
+}

--- a/apps/www/src/routes/admin/route.tsx
+++ b/apps/www/src/routes/admin/route.tsx
@@ -1,0 +1,43 @@
+import {createFileRoute, Link, Outlet} from '@tanstack/react-router';
+import {NAV_ITEMS} from '../../components/admin/nav';
+
+export const Route = createFileRoute('/admin')({
+  // AUTH PLACEHOLDER — the auth task replaces this with a real session check;
+  // do not add logic here now. Returning nothing allows everyone through.
+  beforeLoad: () => {},
+  component: AdminLayout,
+});
+
+function AdminLayout() {
+  return (
+    <div className="flex min-h-screen bg-bg text-text">
+      <aside className="flex w-56 shrink-0 flex-col border-r border-border bg-surface">
+        <div className="border-b border-border px-5 py-4">
+          <div className="font-display text-base font-bold uppercase tracking-wide text-gold">
+            PghBeer
+          </div>
+          <div className="text-[11px] text-text-secondary">Admin</div>
+        </div>
+        <nav className="flex flex-col gap-1 p-3">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              className="rounded-lg px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-alt hover:text-text"
+              activeProps={{
+                className:
+                  'rounded-lg px-3 py-2 text-sm font-semibold bg-surface-alt text-gold',
+              }}
+              activeOptions={item.exact ? {exact: true} : undefined}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      <main className="flex-1 overflow-y-auto p-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/apps/www/tests/components/admin/DataTable.test.ts
+++ b/apps/www/tests/components/admin/DataTable.test.ts
@@ -78,6 +78,10 @@ describe('formatDependents', function () {
     expect(formatDependents({beers: 2, events: 0})).toBe('used by 2 beers');
   });
 
+  it('should singularize an "-ies" plural for a count of one', function () {
+    expect(formatDependents({breweries: 1})).toBe('used by 1 brewery');
+  });
+
   it('should return an empty string when nothing depends on the entity', function () {
     expect(formatDependents({beers: 0})).toBe('');
   });

--- a/apps/www/tests/components/admin/DataTable.test.ts
+++ b/apps/www/tests/components/admin/DataTable.test.ts
@@ -1,0 +1,84 @@
+import {describe, expect, it} from 'bun:test';
+
+import {filterRows} from '../../../src/components/admin/DataTable';
+import type {Column} from '../../../src/components/admin/DataTable';
+import {formatDependents} from '../../../src/components/admin/ConfirmDelete';
+
+type Brewery = {id: number; name: string; city: string; active: boolean};
+
+function makeBrewery(overrides: Partial<Brewery> = {}): Brewery {
+  return {id: 1, name: 'Acme Brewing', city: 'Pittsburgh', active: true, ...overrides};
+}
+
+const columns: Column<Brewery>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
+  {id: 'city', header: 'City', accessor: (row) => row.city},
+  {id: 'active', header: 'Active', accessor: (row) => row.active},
+];
+
+describe('filterRows', function () {
+  it('should narrow rows to those matching a first-column accessor', function () {
+    const rows = [
+      makeBrewery({id: 1, name: 'Acme Brewing'}),
+      makeBrewery({id: 2, name: 'Hop House'}),
+    ];
+
+    const result = filterRows(rows, columns, 'acme');
+
+    expect(result).toEqual([rows[0]!]);
+  });
+
+  it('should match a value in a non-first column', function () {
+    const rows = [
+      makeBrewery({id: 1, city: 'Pittsburgh'}),
+      makeBrewery({id: 2, city: 'Cleveland'}),
+    ];
+
+    const result = filterRows(rows, columns, 'cleveland');
+
+    expect(result).toEqual([rows[1]!]);
+  });
+
+  it('should stringify non-string accessors when matching', function () {
+    const rows = [
+      makeBrewery({id: 1, active: true}),
+      makeBrewery({id: 2, active: false}),
+    ];
+
+    const result = filterRows(rows, columns, 'false');
+
+    expect(result).toEqual([rows[1]!]);
+  });
+
+  it('should return an empty array when no rows match', function () {
+    const rows = [makeBrewery({name: 'Acme Brewing'})];
+
+    expect(filterRows(rows, columns, 'zzz')).toEqual([]);
+  });
+
+  it('should return all rows for an empty query', function () {
+    const rows = [makeBrewery({id: 1}), makeBrewery({id: 2})];
+
+    expect(filterRows(rows, columns, '')).toEqual(rows);
+  });
+
+  it('should return all rows for a whitespace-only query', function () {
+    const rows = [makeBrewery({id: 1}), makeBrewery({id: 2})];
+
+    expect(filterRows(rows, columns, '   ')).toEqual(rows);
+  });
+});
+
+describe('formatDependents', function () {
+  it('should join multiple counts with proper singular/plural', function () {
+    expect(formatDependents({beers: 3, events: 1})).toBe('used by 3 beers and 1 event');
+  });
+
+  it('should omit zero counts', function () {
+    expect(formatDependents({beers: 2, events: 0})).toBe('used by 2 beers');
+  });
+
+  it('should return an empty string when nothing depends on the entity', function () {
+    expect(formatDependents({beers: 0})).toBe('');
+  });
+});


### PR DESCRIPTION
## What

Ships the operator-facing `/admin` **foundation only** so the entity-CRUD pages (breweries, styles, beers, events) can be built in parallel by separate tasks without colliding on shared files.

- **`/admin` layout route** (`routes/admin/route.tsx`) — two-pane shell (fixed left rail + scrollable `<Outlet/>`) styled with the existing design tokens (`bg`, `surface`, `border`, `gold`, `font-display`).
- **Passthrough auth guard** — `beforeLoad` is a clearly-commented stub that allows everyone. A later auth task replaces it with a real session check.
- **Data-driven left rail** — `components/admin/nav.ts` exports a typed `NAV_ITEMS` array pre-listing all five entities. Dashboard uses `activeOptions={{exact: true}}` so it isn't active on sub-routes. **Entity tasks must not edit this array** — their routes 404 until each task lands.
- **Dashboard placeholder** — `routes/admin/index.tsx` (title + blurb, no data fetching).
- **Reusable primitives** in `components/admin/`:
  - `<DataTable>` — generic over a row type, built-in client-side text filter. The predicate is extracted to a pure exported `filterRows(rows, columns, query)` so it's unit-testable without a DOM harness. Filtered rows memoized with `useMemo`; filter input labeled via `useId()`.
  - `<EntityForm>` — discriminated-union field defs (`text`/`number`/`checkbox`/`select`), modal or inline, each control bound to a `useId()`-derived id (instance-proof).
  - `<ConfirmDelete>` — 409-aware: blocks deletion when `dependents` is non-empty. Pure exported `formatDependents()` renders human text.

## Server-fn convention

`lib/admin/server-fn.ts` is a **server-only** module exposing `adminFetch(path, init)`. It:

- resolves the base URL from `process.env.API_URL ?? process.env.VITE_API_URL ?? 'http://localhost:3001'`,
- reads the key from `process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? ''`,
- attaches `Authorization: Bearer <key>` + `Content-Type: application/json`,
- throws on non-ok with status + parsed body.

It deliberately does **not** import `lib/constants.ts` (which exposes keys client-side via `import.meta.env`). Each entity task adds its **own** `lib/admin/<entity>.ts` wrapping `adminFetch` inside `createServerFn` handlers — there is no single shared client file, so `ADMIN_API_KEY` stays server-side and is never bundled to the client. The file carries a commented illustrative example (no runtime export, to satisfy the no-dead-code rule).

## Verification

- `bun run typecheck` — exits 0 (after `routeTree.gen.ts` regenerated by the dev server).
- `bun test` — 69 pass / 0 fail, including the new `apps/www/tests/components/admin/DataTable.test.ts` (9 tests covering `filterRows` narrowing across all column accessors, `[]` on no match, all-rows on empty/whitespace query; plus `formatDependents`).
- SSR HTML at `GET /admin` renders the shell: all five nav items, Dashboard `aria-current="page"`, dashboard placeholder in the content pane.
- Pure-API-client grep over the admin paths returns nothing; the key is read via `process.env` only with no `VITE_` key reference.

## Out of scope (separate tasks)

Entity CRUD pages + their `lib/admin/<entity>.ts`, Google/session auth (guard stays a passthrough), any `apps/api`/`@domain` change, a React-render/DOM test harness, full mobile-rail responsiveness.