### PR TITLE
feat(api,domain): add admin CRUD write surface

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "@electric-sql/pglite": "^0.2.17",
+    "bun-types": "latest",
+    "drizzle-kit": "^0.31.10"
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import {init as initDomain} from '@domain';
 import {healthRoutes} from './routes/health';
 import {dataForEventRoutes} from './routes/dataforevent';
 import {statsRoutes} from './routes/stats';
+import {adminRoutes} from './routes/admin';
 
 const envSchema = z.object({
   PORT: z.string().default('3001'),
@@ -25,6 +26,7 @@ app.use('/*', cors());
 app.route('/', healthRoutes);
 app.route('/', dataForEventRoutes);
 app.route('/', statsRoutes);
+app.route('/admin', adminRoutes);
 
 app.onError((err, c) => {
   const message = err instanceof Error ? err.message : 'Internal server error';

--- a/apps/api/src/routes/admin/beers.ts
+++ b/apps/api/src/routes/admin/beers.ts
@@ -1,0 +1,51 @@
+import {Hono} from 'hono';
+import {
+  createBeer,
+  createBeerSchema,
+  deleteBeer,
+  listBeers,
+  updateBeer,
+  updateBeerSchema,
+} from '@domain';
+
+export const beerRoutes = new Hono();
+
+beerRoutes.get('/', async (c) => {
+  return c.json(await listBeers());
+});
+
+beerRoutes.post('/', async (c) => {
+  const parsed = createBeerSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  return c.json(await createBeer(parsed.data), 201);
+});
+
+beerRoutes.patch('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const parsed = updateBeerSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  const updated = await updateBeer(id, parsed.data);
+  if (!updated) return c.json({error: 'not found'}, 404);
+
+  return c.json(updated);
+});
+
+beerRoutes.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const result = await deleteBeer(id);
+  if (!result.ok) {
+    return c.json({error: 'has dependents', dependents: result.dependents}, 409);
+  }
+
+  return c.json({ok: true});
+});

--- a/apps/api/src/routes/admin/breweries.ts
+++ b/apps/api/src/routes/admin/breweries.ts
@@ -1,0 +1,51 @@
+import {Hono} from 'hono';
+import {
+  createBrewery,
+  createBrewerySchema,
+  deleteBrewery,
+  listBreweries,
+  updateBrewery,
+  updateBrewerySchema,
+} from '@domain';
+
+export const breweryRoutes = new Hono();
+
+breweryRoutes.get('/', async (c) => {
+  return c.json(await listBreweries());
+});
+
+breweryRoutes.post('/', async (c) => {
+  const parsed = createBrewerySchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  return c.json(await createBrewery(parsed.data), 201);
+});
+
+breweryRoutes.patch('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const parsed = updateBrewerySchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  const updated = await updateBrewery(id, parsed.data);
+  if (!updated) return c.json({error: 'not found'}, 404);
+
+  return c.json(updated);
+});
+
+breweryRoutes.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const result = await deleteBrewery(id);
+  if (!result.ok) {
+    return c.json({error: 'has dependents', dependents: result.dependents}, 409);
+  }
+
+  return c.json({ok: true});
+});

--- a/apps/api/src/routes/admin/event-beers.ts
+++ b/apps/api/src/routes/admin/event-beers.ts
@@ -1,0 +1,42 @@
+import {Hono} from 'hono';
+import {
+  addBeerToEvent,
+  addBeerToEventSchema,
+  listBeersForEvent,
+  removeBeerFromEvent,
+} from '@domain';
+
+// Mounted on the same `/events` base as eventRoutes; paths are deeper
+// (`/:id/beers`) so they don't collide with the event CRUD routes.
+export const eventBeerRoutes = new Hono();
+
+eventBeerRoutes.get('/:id/beers', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  return c.json(await listBeersForEvent(id));
+});
+
+eventBeerRoutes.post('/:id/beers', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const parsed = addBeerToEventSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  await addBeerToEvent(id, parsed.data.beerId);
+  return c.json({ok: true});
+});
+
+eventBeerRoutes.delete('/:id/beers/:beerId', async (c) => {
+  const id = Number(c.req.param('id'));
+  const beerId = Number(c.req.param('beerId'));
+  if (Number.isNaN(id) || Number.isNaN(beerId)) {
+    return c.json({error: 'invalid id'}, 400);
+  }
+
+  await removeBeerFromEvent(id, beerId);
+  return c.json({ok: true});
+});

--- a/apps/api/src/routes/admin/events.ts
+++ b/apps/api/src/routes/admin/events.ts
@@ -1,0 +1,51 @@
+import {Hono} from 'hono';
+import {
+  createEvent,
+  createEventSchema,
+  deleteEvent,
+  listEvents,
+  updateEvent,
+  updateEventSchema,
+} from '@domain';
+
+export const eventRoutes = new Hono();
+
+eventRoutes.get('/', async (c) => {
+  return c.json(await listEvents());
+});
+
+eventRoutes.post('/', async (c) => {
+  const parsed = createEventSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  return c.json(await createEvent(parsed.data), 201);
+});
+
+eventRoutes.patch('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const parsed = updateEventSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  const updated = await updateEvent(id, parsed.data);
+  if (!updated) return c.json({error: 'not found'}, 404);
+
+  return c.json(updated);
+});
+
+eventRoutes.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const result = await deleteEvent(id);
+  if (!result.ok) {
+    return c.json({error: 'has dependents', dependents: result.dependents}, 409);
+  }
+
+  return c.json({ok: true});
+});

--- a/apps/api/src/routes/admin/index.ts
+++ b/apps/api/src/routes/admin/index.ts
@@ -1,0 +1,20 @@
+import {Hono} from 'hono';
+import {authMiddleware} from '../../middleware/auth';
+import {env} from '../../index';
+import {breweryRoutes} from './breweries';
+import {styleRoutes} from './styles';
+import {beerRoutes} from './beers';
+import {eventRoutes} from './events';
+import {eventBeerRoutes} from './event-beers';
+
+export const adminRoutes = new Hono();
+
+const auth = authMiddleware(() => env.API_KEY);
+
+adminRoutes.use('/*', auth);
+
+adminRoutes.route('/breweries', breweryRoutes);
+adminRoutes.route('/styles', styleRoutes);
+adminRoutes.route('/beers', beerRoutes);
+adminRoutes.route('/events', eventRoutes);
+adminRoutes.route('/events', eventBeerRoutes);

--- a/apps/api/src/routes/admin/styles.ts
+++ b/apps/api/src/routes/admin/styles.ts
@@ -1,0 +1,51 @@
+import {Hono} from 'hono';
+import {
+  createStyle,
+  createStyleSchema,
+  deleteStyle,
+  listStyles,
+  updateStyle,
+  updateStyleSchema,
+} from '@domain';
+
+export const styleRoutes = new Hono();
+
+styleRoutes.get('/', async (c) => {
+  return c.json(await listStyles());
+});
+
+styleRoutes.post('/', async (c) => {
+  const parsed = createStyleSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  return c.json(await createStyle(parsed.data), 201);
+});
+
+styleRoutes.patch('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const parsed = updateStyleSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    return c.json({error: parsed.error.flatten()}, 400);
+  }
+
+  const updated = await updateStyle(id, parsed.data);
+  if (!updated) return c.json({error: 'not found'}, 404);
+
+  return c.json(updated);
+});
+
+styleRoutes.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) return c.json({error: 'invalid id'}, 400);
+
+  const result = await deleteStyle(id);
+  if (!result.ok) {
+    return c.json({error: 'has dependents', dependents: result.dependents}, 409);
+  }
+
+  return c.json({ok: true});
+});

--- a/apps/api/tests/admin-routes.test.ts
+++ b/apps/api/tests/admin-routes.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'bun:test';
+import {Hono} from 'hono';
+
+import {authMiddleware} from '../src/middleware/auth';
+import {breweryRoutes} from '../src/routes/admin/breweries';
+
+// These cases never reach a domain command: the auth middleware rejects before
+// the handler (401), and zod validation rejects before the DB call (400). So
+// no database is needed — this mirrors how adminRoutes wires auth + sub-routers
+// without importing the env-coupled admin/index.ts.
+function buildApp(apiKey: string) {
+  const app = new Hono();
+  app.use('/*', authMiddleware(() => apiKey));
+  app.route('/breweries', breweryRoutes);
+  return app;
+}
+
+describe('admin route auth', function () {
+  it('should return 401 when the Authorization header is missing', async function () {
+    const app = buildApp('secret');
+
+    const res = await app.request('/breweries');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when the bearer token does not match', async function () {
+    const app = buildApp('secret');
+
+    const res = await app.request('/breweries', {
+      headers: {Authorization: 'Bearer wrong'},
+    });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('admin route validation', function () {
+  it('should return 400 when the request body fails schema validation', async function () {
+    const app = buildApp('secret');
+
+    const res = await app.request('/breweries', {
+      method: 'POST',
+      headers: {Authorization: 'Bearer secret', 'Content-Type': 'application/json'},
+      body: JSON.stringify({name: ''}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/tests/admin-routes.test.ts
+++ b/apps/api/tests/admin-routes.test.ts
@@ -1,8 +1,27 @@
-import {describe, expect, it} from 'bun:test';
+import {PGlite} from '@electric-sql/pglite';
+import {beforeEach, describe, expect, it} from 'bun:test';
+import {createBeer, createBrewery, createStyle, setDatabaseForTests} from '@domain';
+import {type Database} from 'database';
+import * as schema from 'database';
+import {pushSchema} from 'drizzle-kit/api';
+import {drizzle} from 'drizzle-orm/pglite';
 import {Hono} from 'hono';
 
 import {authMiddleware} from '../src/middleware/auth';
 import {breweryRoutes} from '../src/routes/admin/breweries';
+
+// Bootstraps a fresh in-memory pglite and injects it into the domain singleton.
+// Mirrors packages/domain/tests/helpers/test-db.ts; the helper can't be shared
+// because cross-package imports into another package's tests dir are disallowed.
+async function setupTestDb(): Promise<void> {
+  const db = drizzle(new PGlite(), {schema});
+  const {apply} = await pushSchema(
+    schema as unknown as Record<string, unknown>,
+    db as never,
+  );
+  await apply();
+  setDatabaseForTests(db as unknown as Database);
+}
 
 // These cases never reach a domain command: the auth middleware rejects before
 // the handler (401), and zod validation rejects before the DB call (400). So
@@ -46,5 +65,33 @@ describe('admin route validation', function () {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe('admin route blocked delete', function () {
+  beforeEach(async function () {
+    await setupTestDb();
+  });
+
+  it('should return 409 with dependents when the row has dependents', async function () {
+    const brewery = await createBrewery({name: 'Has Beers'});
+    const style = await createStyle({name: 'IPA'});
+    await createBeer({
+      name: 'Flagship',
+      abv: 6.5,
+      beverageType: 'beer',
+      isNa: false,
+      breweryId: brewery.id,
+      styleId: style.id,
+    });
+
+    const app = buildApp('secret');
+    const res = await app.request(`/breweries/${brewery.id}`, {
+      method: 'DELETE',
+      headers: {Authorization: 'Bearer secret'},
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({error: 'has dependents', dependents: {beers: 1}});
   });
 });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "tests"]
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "google-sheets": "workspace:*"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.2.17",
     "@types/bun": "latest",
     "concurrently": "^9.1.2",
     "dotenv": "^17.3.1",
+    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "prettier": "^3.3.0",
     "zod": "^3.23.8"
@@ -29,6 +31,8 @@
     "build:www": "cd apps/www && bun run build",
     "typecheck": "concurrently bun:typecheck:*",
     "typecheck:www": "cd apps/www && bun run typecheck",
+    "typecheck:api": "cd apps/api && tsc --noEmit",
+    "typecheck:domain": "cd packages/domain && tsc --noEmit",
     "typecheck:google-sheets": "cd packages/google-sheets && bun run typecheck",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "test": "bun test",

--- a/packages/database/schema/index.ts
+++ b/packages/database/schema/index.ts
@@ -6,3 +6,12 @@ export {events} from './event.schema';
 export {stats} from './stat.schema';
 export {styles} from './style.schema';
 export {users} from './user.schema';
+export {
+  beersIdSeq,
+  breweriesIdSeq,
+  eventbeerlistIdSeq,
+  eventsIdSeq,
+  statsIdSeq,
+  stylesIdSeq,
+  usersIdSeq,
+} from './sequences';

--- a/packages/database/schema/sequences.ts
+++ b/packages/database/schema/sequences.ts
@@ -4,7 +4,7 @@ export const beersIdSeq = pgSequence('beers_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -13,7 +13,7 @@ export const breweriesIdSeq = pgSequence('breweries_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -22,7 +22,7 @@ export const eventbeerlistIdSeq = pgSequence('eventbeerlist_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -31,7 +31,7 @@ export const eventsIdSeq = pgSequence('events_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -40,7 +40,7 @@ export const statsIdSeq = pgSequence('stats_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -49,7 +49,7 @@ export const stylesIdSeq = pgSequence('styles_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });
@@ -58,7 +58,7 @@ export const usersIdSeq = pgSequence('users_id_seq', {
   startWith: 1,
   increment: 1,
   minValue: 1,
-  maxValue: 9223372036854775807n,
+  maxValue: '9223372036854775807',
   cache: 1,
   cycle: false,
 });

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -9,6 +9,8 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "@electric-sql/pglite": "^0.2.17",
+    "bun-types": "latest",
+    "drizzle-kit": "^0.31.10"
   }
 }

--- a/packages/domain/src/commands/add-beer-to-event.ts
+++ b/packages/domain/src/commands/add-beer-to-event.ts
@@ -1,0 +1,23 @@
+import {eventbeerlist} from 'database';
+import {and, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+
+// Idempotent: a beer is either on an event's list or it isn't. Re-adding an
+// existing link is a no-op rather than a duplicate row or an error.
+export async function addBeerToEvent(eventId: number, beerId: number): Promise<void> {
+  const db = getDb();
+
+  const [existing] = await db
+    .select({id: eventbeerlist.id})
+    .from(eventbeerlist)
+    .where(and(eq(eventbeerlist.eventId, eventId), eq(eventbeerlist.beerId, beerId)))
+    .limit(1);
+
+  if (existing) return;
+
+  const now = new Date();
+  await db
+    .insert(eventbeerlist)
+    .values({eventId, beerId, createDate: now, updateDate: now});
+}

--- a/packages/domain/src/commands/create-beer.ts
+++ b/packages/domain/src/commands/create-beer.ts
@@ -1,0 +1,27 @@
+import {beers} from 'database';
+
+import {getDb} from '../db';
+import {findBeerListItem} from '../queries/list-beers';
+import type {BeerListItem, CreateBeerInput} from '../types';
+
+export async function createBeer(input: CreateBeerInput): Promise<BeerListItem> {
+  const db = getDb();
+  const now = new Date();
+  const [created] = await db
+    .insert(beers)
+    .values({
+      name: input.name,
+      abv: input.abv,
+      beverageType: input.beverageType,
+      isNa: input.isNa,
+      breweryId: input.breweryId,
+      styleId: input.styleId,
+      createDate: now,
+      updateDate: now,
+    })
+    .returning({id: beers.id});
+
+  // Re-read through the join to return the brewery/style names.
+  const item = await findBeerListItem(created!.id);
+  return item!;
+}

--- a/packages/domain/src/commands/create-brewery.ts
+++ b/packages/domain/src/commands/create-brewery.ts
@@ -1,0 +1,15 @@
+import {breweries} from 'database';
+
+import {getDb} from '../db';
+import type {BreweryRow, CreateBreweryInput} from '../types';
+
+export async function createBrewery(input: CreateBreweryInput): Promise<BreweryRow> {
+  const db = getDb();
+  const now = new Date();
+  const [created] = await db
+    .insert(breweries)
+    .values({name: input.name, createDate: now, updateDate: now})
+    .returning({id: breweries.id, name: breweries.name});
+
+  return created!;
+}

--- a/packages/domain/src/commands/create-event.ts
+++ b/packages/domain/src/commands/create-event.ts
@@ -1,0 +1,15 @@
+import {events} from 'database';
+
+import {getDb} from '../db';
+import type {CreateEventInput, EventRow} from '../types';
+
+export async function createEvent(input: CreateEventInput): Promise<EventRow> {
+  const db = getDb();
+  const now = new Date();
+  const [created] = await db
+    .insert(events)
+    .values({name: input.name, date: input.date, createDate: now, updateDate: now})
+    .returning({id: events.id, name: events.name, date: events.date});
+
+  return created!;
+}

--- a/packages/domain/src/commands/create-style.ts
+++ b/packages/domain/src/commands/create-style.ts
@@ -1,0 +1,15 @@
+import {styles} from 'database';
+
+import {getDb} from '../db';
+import type {CreateStyleInput, StyleRow} from '../types';
+
+export async function createStyle(input: CreateStyleInput): Promise<StyleRow> {
+  const db = getDb();
+  const now = new Date();
+  const [created] = await db
+    .insert(styles)
+    .values({name: input.name, createDate: now, updateDate: now})
+    .returning({id: styles.id, name: styles.name});
+
+  return created!;
+}

--- a/packages/domain/src/commands/delete-beer.ts
+++ b/packages/domain/src/commands/delete-beer.ts
@@ -1,0 +1,27 @@
+import {beers, eventbeerlist, stats} from 'database';
+import {count, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {DeleteResult} from '../types';
+
+export async function deleteBeer(id: number): Promise<DeleteResult> {
+  const db = getDb();
+
+  const [statRow] = await db
+    .select({count: count()})
+    .from(stats)
+    .where(eq(stats.beerId, id));
+  const [linkRow] = await db
+    .select({count: count()})
+    .from(eventbeerlist)
+    .where(eq(eventbeerlist.beerId, id));
+
+  const statCount = statRow?.count ?? 0;
+  const linkCount = linkRow?.count ?? 0;
+  if (statCount > 0 || linkCount > 0) {
+    return {ok: false, dependents: {stats: statCount, eventLinks: linkCount}};
+  }
+
+  await db.delete(beers).where(eq(beers.id, id));
+  return {ok: true};
+}

--- a/packages/domain/src/commands/delete-brewery.ts
+++ b/packages/domain/src/commands/delete-brewery.ts
@@ -1,0 +1,22 @@
+import {beers, breweries} from 'database';
+import {count, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {DeleteResult} from '../types';
+
+export async function deleteBrewery(id: number): Promise<DeleteResult> {
+  const db = getDb();
+
+  const [dependents] = await db
+    .select({count: count()})
+    .from(beers)
+    .where(eq(beers.breweryId, id));
+
+  const beerCount = dependents?.count ?? 0;
+  if (beerCount > 0) {
+    return {ok: false, dependents: {beers: beerCount}};
+  }
+
+  await db.delete(breweries).where(eq(breweries.id, id));
+  return {ok: true};
+}

--- a/packages/domain/src/commands/delete-event.ts
+++ b/packages/domain/src/commands/delete-event.ts
@@ -1,0 +1,27 @@
+import {eventbeerlist, events, stats} from 'database';
+import {count, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {DeleteResult} from '../types';
+
+export async function deleteEvent(id: number): Promise<DeleteResult> {
+  const db = getDb();
+
+  const [linkRow] = await db
+    .select({count: count()})
+    .from(eventbeerlist)
+    .where(eq(eventbeerlist.eventId, id));
+  const [statRow] = await db
+    .select({count: count()})
+    .from(stats)
+    .where(eq(stats.eventId, id));
+
+  const linkCount = linkRow?.count ?? 0;
+  const statCount = statRow?.count ?? 0;
+  if (linkCount > 0 || statCount > 0) {
+    return {ok: false, dependents: {eventLinks: linkCount, stats: statCount}};
+  }
+
+  await db.delete(events).where(eq(events.id, id));
+  return {ok: true};
+}

--- a/packages/domain/src/commands/delete-style.ts
+++ b/packages/domain/src/commands/delete-style.ts
@@ -1,0 +1,22 @@
+import {beers, styles} from 'database';
+import {count, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {DeleteResult} from '../types';
+
+export async function deleteStyle(id: number): Promise<DeleteResult> {
+  const db = getDb();
+
+  const [dependents] = await db
+    .select({count: count()})
+    .from(beers)
+    .where(eq(beers.styleId, id));
+
+  const beerCount = dependents?.count ?? 0;
+  if (beerCount > 0) {
+    return {ok: false, dependents: {beers: beerCount}};
+  }
+
+  await db.delete(styles).where(eq(styles.id, id));
+  return {ok: true};
+}

--- a/packages/domain/src/commands/remove-beer-from-event.ts
+++ b/packages/domain/src/commands/remove-beer-from-event.ts
@@ -1,0 +1,14 @@
+import {eventbeerlist} from 'database';
+import {and, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+
+export async function removeBeerFromEvent(
+  eventId: number,
+  beerId: number,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(eventbeerlist)
+    .where(and(eq(eventbeerlist.eventId, eventId), eq(eventbeerlist.beerId, beerId)));
+}

--- a/packages/domain/src/commands/update-beer.ts
+++ b/packages/domain/src/commands/update-beer.ts
@@ -1,0 +1,23 @@
+import {beers} from 'database';
+import {eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import {findBeerListItem} from '../queries/list-beers';
+import type {BeerListItem, UpdateBeerInput} from '../types';
+
+export async function updateBeer(
+  id: number,
+  input: UpdateBeerInput,
+): Promise<BeerListItem | null> {
+  const db = getDb();
+
+  const [updated] = await db
+    .update(beers)
+    .set({...input, updateDate: new Date()})
+    .where(eq(beers.id, id))
+    .returning({id: beers.id});
+
+  if (!updated) return null;
+
+  return findBeerListItem(updated.id);
+}

--- a/packages/domain/src/commands/update-brewery.ts
+++ b/packages/domain/src/commands/update-brewery.ts
@@ -1,0 +1,19 @@
+import {breweries} from 'database';
+import {eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {BreweryRow, UpdateBreweryInput} from '../types';
+
+export async function updateBrewery(
+  id: number,
+  input: UpdateBreweryInput,
+): Promise<BreweryRow | null> {
+  const db = getDb();
+  const [updated] = await db
+    .update(breweries)
+    .set({name: input.name, updateDate: new Date()})
+    .where(eq(breweries.id, id))
+    .returning({id: breweries.id, name: breweries.name});
+
+  return updated ?? null;
+}

--- a/packages/domain/src/commands/update-event.ts
+++ b/packages/domain/src/commands/update-event.ts
@@ -1,0 +1,19 @@
+import {events} from 'database';
+import {eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {EventRow, UpdateEventInput} from '../types';
+
+export async function updateEvent(
+  id: number,
+  input: UpdateEventInput,
+): Promise<EventRow | null> {
+  const db = getDb();
+  const [updated] = await db
+    .update(events)
+    .set({name: input.name, date: input.date, updateDate: new Date()})
+    .where(eq(events.id, id))
+    .returning({id: events.id, name: events.name, date: events.date});
+
+  return updated ?? null;
+}

--- a/packages/domain/src/commands/update-style.ts
+++ b/packages/domain/src/commands/update-style.ts
@@ -1,0 +1,19 @@
+import {styles} from 'database';
+import {eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {StyleRow, UpdateStyleInput} from '../types';
+
+export async function updateStyle(
+  id: number,
+  input: UpdateStyleInput,
+): Promise<StyleRow | null> {
+  const db = getDb();
+  const [updated] = await db
+    .update(styles)
+    .set({name: input.name, updateDate: new Date()})
+    .where(eq(styles.id, id))
+    .returning({id: styles.id, name: styles.name});
+
+  return updated ?? null;
+}

--- a/packages/domain/src/db.ts
+++ b/packages/domain/src/db.ts
@@ -11,3 +11,10 @@ export function getDb(): Database {
   if (!instance) throw new Error('domain not initialized — call init() first');
   return instance;
 }
+
+// Test-only injection point. pglite's PgliteDatabase is structurally compatible
+// with the queries we run but not nominally equal to PostgresJsDatabase, so the
+// cast lives once at the test boundary (see drizzle repo-boundary rule).
+export function setDatabaseForTests(db: Database): void {
+  instance = db;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,31 +1,76 @@
-export {init} from './db';
+export {init, setDatabaseForTests} from './db';
 
 // queries
 export {dashboardStats} from './queries/dashboard-stats';
 export {dataForEvent} from './queries/data-for-event';
 export {statsForEvent} from './queries/stats-for-event';
+export {listBreweries} from './queries/list-breweries';
+export {listStyles} from './queries/list-styles';
+export {listBeers} from './queries/list-beers';
+export {listEvents} from './queries/list-events';
+export {listBeersForEvent} from './queries/list-beers-for-event';
 
 // commands
 export {updateStats} from './commands/update-stats';
 export {findOrCreateUser} from './commands/find-or-create-user';
+export {createBrewery} from './commands/create-brewery';
+export {updateBrewery} from './commands/update-brewery';
+export {deleteBrewery} from './commands/delete-brewery';
+export {createStyle} from './commands/create-style';
+export {updateStyle} from './commands/update-style';
+export {deleteStyle} from './commands/delete-style';
+export {createBeer} from './commands/create-beer';
+export {updateBeer} from './commands/update-beer';
+export {deleteBeer} from './commands/delete-beer';
+export {createEvent} from './commands/create-event';
+export {updateEvent} from './commands/update-event';
+export {deleteEvent} from './commands/delete-event';
+export {addBeerToEvent} from './commands/add-beer-to-event';
+export {removeBeerFromEvent} from './commands/remove-beer-from-event';
 
 // types
 export type {
+  AddBeerToEventInput,
   Beer,
+  BeerListItem,
   Brewery,
+  BreweryRow,
   ColdSpots,
+  CreateBeerInput,
+  CreateBreweryInput,
+  CreateEventInput,
+  CreateStyleInput,
   DashboardStats,
+  DeleteResult,
   DistributionBucket,
   EventBeerItem,
   EventData,
   EventInfo,
+  EventRow,
   StatItem,
   Style,
+  StyleRow,
   StyleTrendBucket,
   TopBeer,
   TopBrewery,
   TypeCount,
+  UpdateBeerInput,
+  UpdateBreweryInput,
+  UpdateEventInput,
   UpdateStatsInput,
+  UpdateStyleInput,
   VelocityBucket,
 } from './types';
-export {StatOpinion, updateStatsSchema} from './types';
+export {
+  addBeerToEventSchema,
+  createBeerSchema,
+  createBrewerySchema,
+  createEventSchema,
+  createStyleSchema,
+  StatOpinion,
+  updateBeerSchema,
+  updateBrewerySchema,
+  updateEventSchema,
+  updateStatsSchema,
+  updateStyleSchema,
+} from './types';

--- a/packages/domain/src/queries/list-beers-for-event.ts
+++ b/packages/domain/src/queries/list-beers-for-event.ts
@@ -1,0 +1,20 @@
+import {beers, breweries, eventbeerlist, styles} from 'database';
+import {asc, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {BeerListItem} from '../types';
+import {beerListColumns, toBeerListItem} from './list-beers';
+
+export async function listBeersForEvent(eventId: number): Promise<BeerListItem[]> {
+  const db = getDb();
+  const rows = await db
+    .select(beerListColumns)
+    .from(eventbeerlist)
+    .innerJoin(beers, eq(eventbeerlist.beerId, beers.id))
+    .innerJoin(breweries, eq(beers.breweryId, breweries.id))
+    .innerJoin(styles, eq(beers.styleId, styles.id))
+    .where(eq(eventbeerlist.eventId, eventId))
+    .orderBy(asc(beers.name));
+
+  return rows.map(toBeerListItem);
+}

--- a/packages/domain/src/queries/list-beers.ts
+++ b/packages/domain/src/queries/list-beers.ts
@@ -1,0 +1,69 @@
+import {beers, breweries, styles} from 'database';
+import {asc, eq} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {BeerListItem} from '../types';
+
+// Shared join projection for the admin beer shape: ids + names on both
+// relations. Used by listBeers, listBeersForEvent (filtered), and the
+// create/update commands (single-id re-read).
+export const beerListColumns = {
+  id: beers.id,
+  name: beers.name,
+  abv: beers.abv,
+  beverageType: beers.beverageType,
+  isNa: beers.isNa,
+  breweryId: breweries.id,
+  breweryName: breweries.name,
+  styleId: styles.id,
+  styleName: styles.name,
+};
+
+type BeerListRow = {
+  id: number;
+  name: string;
+  abv: number | null;
+  beverageType: BeerListItem['beverageType'];
+  isNa: boolean;
+  breweryId: number;
+  breweryName: string;
+  styleId: number;
+  styleName: string;
+};
+
+export function toBeerListItem(row: BeerListRow): BeerListItem {
+  return {
+    id: row.id,
+    name: row.name,
+    abv: row.abv,
+    beverageType: row.beverageType,
+    isNa: row.isNa,
+    brewery: {id: row.breweryId, name: row.breweryName},
+    style: {id: row.styleId, name: row.styleName},
+  };
+}
+
+export async function findBeerListItem(id: number): Promise<BeerListItem | null> {
+  const db = getDb();
+  const [row] = await db
+    .select(beerListColumns)
+    .from(beers)
+    .innerJoin(breweries, eq(beers.breweryId, breweries.id))
+    .innerJoin(styles, eq(beers.styleId, styles.id))
+    .where(eq(beers.id, id))
+    .limit(1);
+
+  return row ? toBeerListItem(row) : null;
+}
+
+export async function listBeers(): Promise<BeerListItem[]> {
+  const db = getDb();
+  const rows = await db
+    .select(beerListColumns)
+    .from(beers)
+    .innerJoin(breweries, eq(beers.breweryId, breweries.id))
+    .innerJoin(styles, eq(beers.styleId, styles.id))
+    .orderBy(asc(beers.name));
+
+  return rows.map(toBeerListItem);
+}

--- a/packages/domain/src/queries/list-breweries.ts
+++ b/packages/domain/src/queries/list-breweries.ts
@@ -1,0 +1,13 @@
+import {breweries} from 'database';
+import {asc} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {BreweryRow} from '../types';
+
+export async function listBreweries(): Promise<BreweryRow[]> {
+  const db = getDb();
+  return db
+    .select({id: breweries.id, name: breweries.name})
+    .from(breweries)
+    .orderBy(asc(breweries.name));
+}

--- a/packages/domain/src/queries/list-events.ts
+++ b/packages/domain/src/queries/list-events.ts
@@ -1,0 +1,13 @@
+import {events} from 'database';
+import {asc} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {EventRow} from '../types';
+
+export async function listEvents(): Promise<EventRow[]> {
+  const db = getDb();
+  return db
+    .select({id: events.id, name: events.name, date: events.date})
+    .from(events)
+    .orderBy(asc(events.date));
+}

--- a/packages/domain/src/queries/list-styles.ts
+++ b/packages/domain/src/queries/list-styles.ts
@@ -1,0 +1,13 @@
+import {styles} from 'database';
+import {asc} from 'drizzle-orm';
+
+import {getDb} from '../db';
+import type {StyleRow} from '../types';
+
+export async function listStyles(): Promise<StyleRow[]> {
+  const db = getDb();
+  return db
+    .select({id: styles.id, name: styles.name})
+    .from(styles)
+    .orderBy(asc(styles.name));
+}

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -1,3 +1,4 @@
+import {beverageTypeEnum, type BeverageType as DbBeverageType} from 'database';
 import {z} from 'zod';
 
 // Shared types matching the API response shapes
@@ -66,6 +67,86 @@ export const updateStatsSchema = z.object({
 });
 
 export type UpdateStatsInput = z.infer<typeof updateStatsSchema>;
+
+// --- Admin CRUD ---
+// Write-surface row shapes returned by the admin endpoints. BeerListItem is
+// intentionally distinct from the read-side Beer type (which uses isNA and a
+// name-only style) — the admin console needs ids on both relations.
+
+export interface BreweryRow {
+  id: number;
+  name: string;
+}
+
+export interface StyleRow {
+  id: number;
+  name: string;
+}
+
+export interface EventRow {
+  id: number;
+  name: string;
+  date: string;
+}
+
+export interface BeerListItem {
+  id: number;
+  name: string;
+  abv: number | null;
+  beverageType: BeverageType;
+  isNa: boolean;
+  brewery: {id: number; name: string};
+  style: {id: number; name: string};
+}
+
+// Safe-delete result: deletes refuse rather than cascade. When dependents
+// exist the command returns the per-entity counts and performs no delete.
+export type DeleteResult =
+  | {ok: true}
+  | {ok: false; dependents: Record<string, number>};
+
+// Cast the readonly drizzle enumValues to z.enum's mutable-tuple shape while
+// preserving the literal union so the inferred input matches the DB column
+// type (the 7 DB values — 'na' is the separate isNa boolean, not a value here).
+const beverageTypeSchema = z.enum(
+  beverageTypeEnum.enumValues as unknown as [DbBeverageType, ...DbBeverageType[]],
+);
+
+export const createBrewerySchema = z.object({name: z.string().min(1)});
+export const updateBrewerySchema = z.object({name: z.string().min(1)});
+export type CreateBreweryInput = z.infer<typeof createBrewerySchema>;
+export type UpdateBreweryInput = z.infer<typeof updateBrewerySchema>;
+
+export const createStyleSchema = z.object({name: z.string().min(1)});
+export const updateStyleSchema = z.object({name: z.string().min(1)});
+export type CreateStyleInput = z.infer<typeof createStyleSchema>;
+export type UpdateStyleInput = z.infer<typeof updateStyleSchema>;
+
+export const createBeerSchema = z.object({
+  name: z.string().min(1),
+  abv: z.number().nullable(),
+  beverageType: beverageTypeSchema,
+  isNa: z.boolean(),
+  breweryId: z.number().int(),
+  styleId: z.number().int(),
+});
+export const updateBeerSchema = createBeerSchema.partial();
+export type CreateBeerInput = z.infer<typeof createBeerSchema>;
+export type UpdateBeerInput = z.infer<typeof updateBeerSchema>;
+
+export const createEventSchema = z.object({
+  name: z.string().min(1),
+  date: z.string().min(1),
+});
+export const updateEventSchema = z.object({
+  name: z.string().min(1),
+  date: z.string().min(1),
+});
+export type CreateEventInput = z.infer<typeof createEventSchema>;
+export type UpdateEventInput = z.infer<typeof updateEventSchema>;
+
+export const addBeerToEventSchema = z.object({beerId: z.number().int()});
+export type AddBeerToEventInput = z.infer<typeof addBeerToEventSchema>;
 
 export interface VelocityBucket {
   bucket: string;

--- a/packages/domain/tests/beer.test.ts
+++ b/packages/domain/tests/beer.test.ts
@@ -1,0 +1,104 @@
+import {beforeEach, describe, expect, it} from 'bun:test';
+
+import {
+  addBeerToEvent,
+  createBeer,
+  createBrewery,
+  createEvent,
+  createStyle,
+  deleteBeer,
+  listBeers,
+  updateBeer,
+} from '../src/index';
+import type {CreateBeerInput} from '../src/index';
+import {setupTestDb} from './helpers/test-db';
+
+async function seedBeer(overrides: Partial<CreateBeerInput> = {}) {
+  const brewery = await createBrewery({name: 'East End Brewing'});
+  const style = await createStyle({name: 'Amber Ale'});
+  const beer = await createBeer({
+    name: 'Big Hop',
+    abv: 7.2,
+    beverageType: 'beer',
+    isNa: false,
+    breweryId: brewery.id,
+    styleId: style.id,
+    ...overrides,
+  });
+  return {brewery, style, beer};
+}
+
+beforeEach(async function () {
+  await setupTestDb();
+});
+
+describe('createBeer', function () {
+  it('should return the joined shape with brewery and style names', async function () {
+    const {brewery, style, beer} = await seedBeer();
+
+    expect(beer).toEqual({
+      id: beer.id,
+      name: 'Big Hop',
+      abv: 7.2,
+      beverageType: 'beer',
+      isNa: false,
+      brewery: {id: brewery.id, name: 'East End Brewing'},
+      style: {id: style.id, name: 'Amber Ale'},
+    });
+  });
+});
+
+describe('listBeers', function () {
+  it('should return objects carrying joined brewery and style names', async function () {
+    const {brewery, style} = await seedBeer();
+
+    const [item] = await listBeers();
+
+    expect(item).toMatchObject({
+      name: 'Big Hop',
+      abv: 7.2,
+      beverageType: 'beer',
+      isNa: false,
+      brewery: {id: brewery.id, name: 'East End Brewing'},
+      style: {id: style.id, name: 'Amber Ale'},
+    });
+  });
+});
+
+describe('updateBeer', function () {
+  it('should partially update and return the joined shape', async function () {
+    const {beer} = await seedBeer();
+
+    const updated = await updateBeer(beer.id, {name: 'Renamed', abv: 4.0});
+
+    expect(updated?.name).toBe('Renamed');
+    expect(updated?.abv).toBe(4.0);
+    expect(updated?.brewery.name).toBe('East End Brewing');
+  });
+
+  it('should return null when the beer does not exist', async function () {
+    expect(await updateBeer(9999, {name: 'Nope'})).toBeNull();
+  });
+});
+
+describe('deleteBeer', function () {
+  it('should delete a beer with no dependents', async function () {
+    const {beer} = await seedBeer();
+
+    const result = await deleteBeer(beer.id);
+
+    expect(result).toEqual({ok: true});
+    expect(await listBeers()).toHaveLength(0);
+  });
+
+  it('should refuse to delete and report event-link dependents', async function () {
+    const {beer} = await seedBeer();
+    const event = await createEvent({name: 'BOTB 2026', date: '2026-04-18'});
+    await addBeerToEvent(event.id, beer.id);
+
+    const result = await deleteBeer(beer.id);
+
+    expect(result).toEqual({ok: false, dependents: {stats: 0, eventLinks: 1}});
+    expect(await listBeers()).toHaveLength(1);
+  });
+});

--- a/packages/domain/tests/brewery.test.ts
+++ b/packages/domain/tests/brewery.test.ts
@@ -1,0 +1,81 @@
+import {beforeEach, describe, expect, it} from 'bun:test';
+
+import {
+  createBeer,
+  createBrewery,
+  createStyle,
+  deleteBrewery,
+  listBreweries,
+  updateBrewery,
+} from '../src/index';
+import {setupTestDb} from './helpers/test-db';
+
+beforeEach(async function () {
+  await setupTestDb();
+});
+
+describe('createBrewery', function () {
+  it('should persist a brewery and return its id and name', async function () {
+    const created = await createBrewery({name: 'Grist House'});
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe('Grist House');
+  });
+});
+
+describe('listBreweries', function () {
+  it('should return breweries ordered by name', async function () {
+    await createBrewery({name: 'Zelienople Brewing'});
+    await createBrewery({name: 'Allegheny City'});
+
+    const names = (await listBreweries()).map((b) => b.name);
+
+    expect(names).toEqual(['Allegheny City', 'Zelienople Brewing']);
+  });
+});
+
+describe('updateBrewery', function () {
+  it('should rename an existing brewery', async function () {
+    const created = await createBrewery({name: 'Old Name'});
+
+    const updated = await updateBrewery(created.id, {name: 'New Name'});
+
+    expect(updated).toEqual({id: created.id, name: 'New Name'});
+  });
+
+  it('should return null when the brewery does not exist', async function () {
+    const updated = await updateBrewery(9999, {name: 'Nope'});
+
+    expect(updated).toBeNull();
+  });
+});
+
+describe('deleteBrewery', function () {
+  it('should delete a brewery with no dependents', async function () {
+    const created = await createBrewery({name: 'Disposable'});
+
+    const result = await deleteBrewery(created.id);
+
+    expect(result).toEqual({ok: true});
+    expect(await listBreweries()).toHaveLength(0);
+  });
+
+  it('should refuse to delete and report dependents when beers reference it', async function () {
+    const brewery = await createBrewery({name: 'Has Beers'});
+    const style = await createStyle({name: 'IPA'});
+    await createBeer({
+      name: 'Flagship',
+      abv: 6.5,
+      beverageType: 'beer',
+      isNa: false,
+      breweryId: brewery.id,
+      styleId: style.id,
+    });
+
+    const result = await deleteBrewery(brewery.id);
+
+    expect(result).toEqual({ok: false, dependents: {beers: 1}});
+    // No delete performed.
+    expect(await listBreweries()).toHaveLength(1);
+  });
+});

--- a/packages/domain/tests/event-beers.test.ts
+++ b/packages/domain/tests/event-beers.test.ts
@@ -1,0 +1,77 @@
+import {beforeEach, describe, expect, it} from 'bun:test';
+
+import {
+  addBeerToEvent,
+  createBeer,
+  createBrewery,
+  createEvent,
+  createStyle,
+  listBeersForEvent,
+  removeBeerFromEvent,
+} from '../src/index';
+import {setupTestDb} from './helpers/test-db';
+
+async function seed() {
+  const brewery = await createBrewery({name: 'Dancing Gnome'});
+  const style = await createStyle({name: 'IPA'});
+  const beer = await createBeer({
+    name: 'Lustra',
+    abv: 5.0,
+    beverageType: 'beer',
+    isNa: false,
+    breweryId: brewery.id,
+    styleId: style.id,
+  });
+  const event = await createEvent({name: 'BOTB 2026', date: '2026-04-18'});
+  return {brewery, style, beer, event};
+}
+
+beforeEach(async function () {
+  await setupTestDb();
+});
+
+describe('addBeerToEvent', function () {
+  it('should be idempotent — re-adding the same beer yields one link', async function () {
+    const {beer, event} = await seed();
+
+    await addBeerToEvent(event.id, beer.id);
+    await addBeerToEvent(event.id, beer.id);
+
+    expect(await listBeersForEvent(event.id)).toHaveLength(1);
+  });
+});
+
+describe('listBeersForEvent', function () {
+  it('should return only beers linked to the event in the joined shape', async function () {
+    const {brewery, style, beer, event} = await seed();
+    await addBeerToEvent(event.id, beer.id);
+
+    const [item] = await listBeersForEvent(event.id);
+
+    expect(item).toMatchObject({
+      id: beer.id,
+      name: 'Lustra',
+      brewery: {id: brewery.id, name: 'Dancing Gnome'},
+      style: {id: style.id, name: 'IPA'},
+    });
+  });
+
+  it('should not return beers from other events', async function () {
+    const {beer, event} = await seed();
+    const other = await createEvent({name: 'Other', date: '2026-09-01'});
+    await addBeerToEvent(event.id, beer.id);
+
+    expect(await listBeersForEvent(other.id)).toHaveLength(0);
+  });
+});
+
+describe('removeBeerFromEvent', function () {
+  it('should delete the link row', async function () {
+    const {beer, event} = await seed();
+    await addBeerToEvent(event.id, beer.id);
+
+    await removeBeerFromEvent(event.id, beer.id);
+
+    expect(await listBeersForEvent(event.id)).toHaveLength(0);
+  });
+});

--- a/packages/domain/tests/event.test.ts
+++ b/packages/domain/tests/event.test.ts
@@ -1,0 +1,83 @@
+import {beforeEach, describe, expect, it} from 'bun:test';
+
+import {
+  addBeerToEvent,
+  createBeer,
+  createBrewery,
+  createEvent,
+  createStyle,
+  deleteEvent,
+  listEvents,
+  updateEvent,
+} from '../src/index';
+import {setupTestDb} from './helpers/test-db';
+
+beforeEach(async function () {
+  await setupTestDb();
+});
+
+describe('createEvent', function () {
+  it('should persist an event and return id, name, and date string', async function () {
+    const created = await createEvent({name: 'BOTB 2026', date: '2026-04-18'});
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe('BOTB 2026');
+    expect(created.date).toBe('2026-04-18');
+  });
+});
+
+describe('listEvents', function () {
+  it('should return events ordered by date', async function () {
+    await createEvent({name: 'Later', date: '2026-09-01'});
+    await createEvent({name: 'Earlier', date: '2026-04-18'});
+
+    const names = (await listEvents()).map((e) => e.name);
+
+    expect(names).toEqual(['Earlier', 'Later']);
+  });
+});
+
+describe('updateEvent', function () {
+  it('should update name and date', async function () {
+    const created = await createEvent({name: 'Old', date: '2026-04-18'});
+
+    const updated = await updateEvent(created.id, {name: 'New', date: '2026-05-01'});
+
+    expect(updated).toEqual({id: created.id, name: 'New', date: '2026-05-01'});
+  });
+
+  it('should return null when the event does not exist', async function () {
+    expect(await updateEvent(9999, {name: 'Nope', date: '2026-01-01'})).toBeNull();
+  });
+});
+
+describe('deleteEvent', function () {
+  it('should delete an event with no dependents', async function () {
+    const created = await createEvent({name: 'Disposable', date: '2026-04-18'});
+
+    const result = await deleteEvent(created.id);
+
+    expect(result).toEqual({ok: true});
+    expect(await listEvents()).toHaveLength(0);
+  });
+
+  it('should refuse to delete and report event-link dependents', async function () {
+    const brewery = await createBrewery({name: 'Brewery'});
+    const style = await createStyle({name: 'IPA'});
+    const beer = await createBeer({
+      name: 'Beer',
+      abv: 6,
+      beverageType: 'beer',
+      isNa: false,
+      breweryId: brewery.id,
+      styleId: style.id,
+    });
+    const event = await createEvent({name: 'Has Links', date: '2026-04-18'});
+    await addBeerToEvent(event.id, beer.id);
+
+    const result = await deleteEvent(event.id);
+
+    expect(result).toEqual({ok: false, dependents: {eventLinks: 1, stats: 0}});
+    expect(await listEvents()).toHaveLength(1);
+  });
+});

--- a/packages/domain/tests/helpers/test-db.ts
+++ b/packages/domain/tests/helpers/test-db.ts
@@ -1,0 +1,34 @@
+import {PGlite} from '@electric-sql/pglite';
+import {type Database} from 'database';
+import * as schema from 'database';
+import {pushSchema} from 'drizzle-kit/api';
+import {drizzle} from 'drizzle-orm/pglite';
+
+import {setDatabaseForTests} from '../../src/db';
+
+// Spin up a fresh in-memory pglite, bootstrap the schema programmatically
+// (the committed migrations are introspection ALTERs that produce an empty
+// schema against pglite — see CLAUDE-TASK.md), and inject it into the domain
+// singleton. A fresh DB per call keeps tests isolated despite the module-level
+// `instance` (testing.md: module-level state persists across a run).
+//
+// The `schema` namespace includes both tables and pgSequence definitions, so
+// pushSchema emits CREATE SEQUENCE before the nextval()-defaulted tables.
+export async function setupTestDb(): Promise<Database> {
+  const client = new PGlite();
+  const db = drizzle(client, {schema});
+
+  const {apply} = await pushSchema(
+    schema as unknown as Record<string, unknown>,
+    // pglite's PgliteDatabase is not nominally PgDatabase; cast at this single
+    // test boundary (drizzle repo-boundary rule).
+    db as never,
+  );
+  await apply();
+
+  // PgliteDatabase != PostgresJsDatabase nominally; the queries the domain runs
+  // are structurally compatible. Single cast at the test boundary.
+  const injected = db as unknown as Database;
+  setDatabaseForTests(injected);
+  return injected;
+}

--- a/packages/domain/tests/style.test.ts
+++ b/packages/domain/tests/style.test.ts
@@ -1,0 +1,78 @@
+import {beforeEach, describe, expect, it} from 'bun:test';
+
+import {
+  createBeer,
+  createBrewery,
+  createStyle,
+  deleteStyle,
+  listStyles,
+  updateStyle,
+} from '../src/index';
+import {setupTestDb} from './helpers/test-db';
+
+beforeEach(async function () {
+  await setupTestDb();
+});
+
+describe('createStyle', function () {
+  it('should persist a style and return its id and name', async function () {
+    const created = await createStyle({name: 'Stout'});
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe('Stout');
+  });
+});
+
+describe('listStyles', function () {
+  it('should return styles ordered by name', async function () {
+    await createStyle({name: 'Saison'});
+    await createStyle({name: 'Lager'});
+
+    const names = (await listStyles()).map((s) => s.name);
+
+    expect(names).toEqual(['Lager', 'Saison']);
+  });
+});
+
+describe('updateStyle', function () {
+  it('should rename an existing style', async function () {
+    const created = await createStyle({name: 'Pale Ale'});
+
+    const updated = await updateStyle(created.id, {name: 'Hazy IPA'});
+
+    expect(updated).toEqual({id: created.id, name: 'Hazy IPA'});
+  });
+
+  it('should return null when the style does not exist', async function () {
+    expect(await updateStyle(9999, {name: 'Nope'})).toBeNull();
+  });
+});
+
+describe('deleteStyle', function () {
+  it('should delete a style with no dependents', async function () {
+    const created = await createStyle({name: 'Disposable'});
+
+    const result = await deleteStyle(created.id);
+
+    expect(result).toEqual({ok: true});
+    expect(await listStyles()).toHaveLength(0);
+  });
+
+  it('should refuse to delete and report dependents when beers reference it', async function () {
+    const brewery = await createBrewery({name: 'Brewery'});
+    const style = await createStyle({name: 'Porter'});
+    await createBeer({
+      name: 'Robust Porter',
+      abv: 5.5,
+      beverageType: 'beer',
+      isNa: false,
+      breweryId: brewery.id,
+      styleId: style.id,
+    });
+
+    const result = await deleteStyle(style.id);
+
+    expect(result).toEqual({ok: false, dependents: {beers: 1}});
+    expect(await listStyles()).toHaveLength(1);
+  });
+});

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary

Builds the entire backend the upcoming `/admin` console will call — done once here so the downstream UI tasks never need to touch `apps/api`. The importer (`scripts/import.ts`) remains the bulk path and is untouched.

Three layers, bottom-up:

1. **`@domain` commands + queries** — `create`/`update`/`delete` commands and `list` queries for breweries, styles, beers, events, and event↔beer links (one definition per file), following the existing `update-stats.ts` / `data-for-event.ts` styles. New `BreweryRow`/`StyleRow`/`EventRow`/`BeerListItem`/`DeleteResult` types and `create*`/`update*` zod schemas live in `types.ts`; everything is re-exported from the barrel.
2. **Safe deletes** via a `DeleteResult` discriminated union. Each delete pre-counts dependents and refuses (no cascade) when any exist, so the route can return a structured **409** instead of an opaque FK-`restrict` 500. `deleteBeer`/`deleteEvent` report stable keys (`stats`, `eventLinks`).
3. **Hono routes** under `apps/api/src/routes/admin/`, aggregated into `adminRoutes` and mounted **once** as `app.route('/admin', adminRoutes)`, behind the existing bearer middleware applied once at the aggregate (`use('/*', auth)`). Bodies validated with the `@domain` zod schemas; validation failure → 400, blocked delete → 409 `{error, dependents}`.

## Status codes

`GET` 200 · `POST` create 201 · `PATCH` 200 / 404 on missing id · `DELETE` blocked 409 / else 200 `{ok:true}` (idempotent) · `POST /events/:id/beers` re-add → 200 no-op.

## Tests / verification

- `bun run typecheck` exits **0** (now includes `typecheck:domain` + `typecheck:api`, each with a new `tsconfig.json`).
- `bun test` — **31** new tests pass (28 domain + 3 route). Domain tests use an in-memory pglite bootstrapped via `drizzle-kit` `pushSchema` (the committed migrations are introspection `ALTER`s that no-op on pglite), injected through a new `setDatabaseForTests` hook. Covers create/update/delete happy paths, the joined `listBeers` shape, `addBeerToEvent` idempotency, and the 409/`{ok:false, dependents}` refusal for all four deletes. Route tests cover the **401** (missing/wrong bearer) and **400** (invalid body) paths without a DB.

### Manual curl for the route-level 409 (AC #5)

The 409 mapping is `if (!result.ok) c.json({error, dependents}, 409)`; the refusal logic is proven by the domain delete tests. End-to-end against a seeded Postgres:

```bash
# brewery 1 has dependent beers
curl -i -X DELETE localhost:3001/admin/breweries/1 \
  -H "Authorization: Bearer $API_KEY"
# => HTTP/1.1 409  {"error":"has dependents","dependents":{"beers":3}}
```

## Notes

- The `database` barrel now also exports the existing `pgSequence` defs so `pushSchema` emits `CREATE SEQUENCE` before the `nextval()`-defaulted tables. This surfaced a latent `bigint` `maxValue` type error in `sequences.ts`, fixed by switching to the string form (same value, no production impact).
- No `www`/UI changes, no auth changes, no new env vars, no migrations.

## Scope check

`scripts/import.ts`, `apps/www/**`, and the public read routes (`dataforevent`, `stats` reads, `health`) are untouched.