### PR TITLE
feat(www): add styles admin CRUD page

### DIFF
--- a/apps/www/src/lib/admin/server-fn.ts
+++ b/apps/www/src/lib/admin/server-fn.ts
@@ -21,14 +21,17 @@ function resolveApiKey(): string {
   return process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? '';
 }
 
-export async function adminFetch(
+// Authed fetch that returns the raw Response WITHOUT throwing on non-2xx.
+// Entity delete handlers use this to branch on a 409 "has dependents" body
+// (which adminFetch would otherwise collapse into an opaque thrown Error).
+export async function adminFetchRaw(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
   const url = `${resolveBaseUrl()}${path}`;
   const key = resolveApiKey();
 
-  const res = await fetch(url, {
+  return fetch(url, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
@@ -36,6 +39,13 @@ export async function adminFetch(
       ...init.headers,
     },
   });
+}
+
+export async function adminFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const res = await adminFetchRaw(path, init);
 
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/apps/www/src/lib/admin/styles.ts
+++ b/apps/www/src/lib/admin/styles.ts
@@ -1,0 +1,71 @@
+import {createServerFn} from '@tanstack/react-start';
+import {adminFetch, adminFetchRaw} from './server-fn';
+
+// Local type — apps/www does NOT depend on @domain (no path alias). Mirrors the
+// API's Style shape ({id, name}).
+export type Style = {id: number; name: string};
+
+// Discriminated union matching <ConfirmDelete>'s dependents prop. `ok:false`
+// carries the per-entity dependent counts surfaced by the API's 409 body.
+export type DeleteResult =
+  | {ok: true}
+  | {ok: false; dependents: Record<string, number>};
+
+// Pure, exported for unit testing without a server harness. Maps a DELETE
+// response into a DeleteResult:
+//   200 → {ok:true}
+//   409 → {ok:false, dependents} (defaulting to {} when the body omits them)
+//   any other non-2xx → throw (per error-handling.md, never swallow)
+export function parseDeleteResult(status: number, body: unknown): DeleteResult {
+  if (status === 200) return {ok: true};
+
+  if (status === 409) {
+    const dependents =
+      body && typeof body === 'object' && 'dependents' in body
+        ? ((body as {dependents?: Record<string, number>}).dependents ?? {})
+        : {};
+    return {ok: false, dependents};
+  }
+
+  throw new Error(
+    `Delete failed: ${status} — ${JSON.stringify(body)}`,
+  );
+}
+
+export const listStyles = createServerFn({method: 'GET'}).handler(
+  async () => (await adminFetch('/admin/styles')).json() as Promise<Style[]>,
+);
+
+export const createStyle = createServerFn({method: 'POST'})
+  .inputValidator((data: {name: string}) => data)
+  .handler(
+    async ({data}) =>
+      (
+        await adminFetch('/admin/styles', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        })
+      ).json() as Promise<Style>,
+  );
+
+export const updateStyle = createServerFn({method: 'POST'})
+  .inputValidator((data: {id: number; name: string}) => data)
+  .handler(
+    async ({data}) =>
+      (
+        await adminFetch(`/admin/styles/${data.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({name: data.name}),
+        })
+      ).json() as Promise<Style>,
+  );
+
+export const deleteStyle = createServerFn({method: 'POST'})
+  .inputValidator((data: {id: number}) => data)
+  .handler(async ({data}): Promise<DeleteResult> => {
+    const res = await adminFetchRaw(`/admin/styles/${data.id}`, {
+      method: 'DELETE',
+    });
+    const body = await res.json().catch(() => ({}));
+    return parseDeleteResult(res.status, body);
+  });

--- a/apps/www/src/routes/admin/styles.tsx
+++ b/apps/www/src/routes/admin/styles.tsx
@@ -1,0 +1,151 @@
+import {useState} from 'react';
+import {createFileRoute} from '@tanstack/react-router';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {DataTable} from '../../components/admin/DataTable';
+import {EntityForm} from '../../components/admin/EntityForm';
+import {ConfirmDelete} from '../../components/admin/ConfirmDelete';
+import {
+  createStyle,
+  deleteStyle,
+  listStyles,
+  updateStyle,
+} from '../../lib/admin/styles';
+import type {Style} from '../../lib/admin/styles';
+
+export const Route = createFileRoute('/admin/styles')({
+  head: () => ({
+    meta: [{title: 'PghBeer — Styles'}],
+  }),
+  component: AdminStyles,
+});
+
+const STYLES_QUERY_KEY = ['admin', 'styles'] as const;
+
+type FormState = {mode: 'create'} | {mode: 'edit'; style: Style} | null;
+
+function AdminStyles() {
+  const queryClient = useQueryClient();
+  const stylesQuery = useQuery({
+    queryKey: STYLES_QUERY_KEY,
+    queryFn: () => listStyles(),
+  });
+
+  const [formState, setFormState] = useState<FormState>(null);
+  const [name, setName] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<Style | null>(null);
+  const [deleteDependents, setDeleteDependents] = useState<Record<
+    string,
+    number
+  > | null>(null);
+
+  function invalidate() {
+    return queryClient.invalidateQueries({queryKey: STYLES_QUERY_KEY});
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (formState?.mode === 'edit') {
+        return updateStyle({data: {id: formState.style.id, name}});
+      }
+      return createStyle({data: {name}});
+    },
+    onSuccess: async () => {
+      await invalidate();
+      closeForm();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (style: Style) => deleteStyle({data: {id: style.id}}),
+    onSuccess: async (result) => {
+      if (result.ok) {
+        await invalidate();
+        closeDelete();
+        return;
+      }
+      setDeleteDependents(result.dependents);
+    },
+  });
+
+  function openCreate() {
+    setFormState({mode: 'create'});
+    setName('');
+  }
+
+  function openEdit(style: Style) {
+    setFormState({mode: 'edit', style});
+    setName(style.name);
+  }
+
+  function closeForm() {
+    setFormState(null);
+    setName('');
+  }
+
+  function openDelete(style: Style) {
+    setDeleteTarget(style);
+    setDeleteDependents(null);
+  }
+
+  function closeDelete() {
+    setDeleteTarget(null);
+    setDeleteDependents(null);
+  }
+
+  const styles = stylesQuery.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-2xl font-bold text-gold">Styles</h1>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-check-fg"
+        >
+          New Style
+        </button>
+      </div>
+
+      {stylesQuery.isPending ? (
+        <p className="text-sm text-text-secondary">Loading…</p>
+      ) : stylesQuery.isError ? (
+        <p className="text-sm text-red">Failed to load styles.</p>
+      ) : (
+        <DataTable
+          columns={[{id: 'name', header: 'Name', accessor: (row) => row.name}]}
+          rows={styles}
+          getRowId={(row) => row.id}
+          filterPlaceholder="Filter styles…"
+          actions={(row) => [
+            {label: 'Edit', onClick: () => openEdit(row)},
+            {label: 'Delete', onClick: () => openDelete(row), variant: 'danger'},
+          ]}
+        />
+      )}
+
+      {formState ? (
+        <EntityForm
+          as="modal"
+          fields={[{name: 'name', label: 'Name', type: 'text', required: true}]}
+          values={{name}}
+          onChange={(_, value) =>
+            setName(typeof value === 'string' ? value : '')
+          }
+          onSubmit={() => saveMutation.mutate()}
+          onCancel={closeForm}
+          submitLabel={saveMutation.isPending ? 'Saving…' : 'Save'}
+        />
+      ) : null}
+
+      <ConfirmDelete
+        open={deleteTarget !== null}
+        title="Delete this style?"
+        dependents={deleteDependents ?? undefined}
+        confirming={deleteMutation.isPending}
+        onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget)}
+        onCancel={closeDelete}
+      />
+    </div>
+  );
+}

--- a/apps/www/tests/lib/admin/styles.test.ts
+++ b/apps/www/tests/lib/admin/styles.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'bun:test';
+
+import {parseDeleteResult} from '../../../src/lib/admin/styles';
+
+describe('parseDeleteResult', function () {
+  it('should return ok when the status is 200', function () {
+    expect(parseDeleteResult(200, {ok: true})).toEqual({ok: true});
+  });
+
+  it('should surface dependents when the status is 409', function () {
+    const result = parseDeleteResult(409, {
+      error: 'has dependents',
+      dependents: {beers: 3},
+    });
+
+    expect(result).toEqual({ok: false, dependents: {beers: 3}});
+  });
+
+  it('should default dependents to an empty object when 409 omits them', function () {
+    expect(parseDeleteResult(409, {error: 'has dependents'})).toEqual({
+      ok: false,
+      dependents: {},
+    });
+  });
+
+  it('should throw on any other non-2xx status', function () {
+    expect(() => parseDeleteResult(500, {error: 'boom'})).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first real admin entity page at `/admin/styles` — the worked reference the Breweries/Beers/Events pages will mirror. Styles are the simplest entity (`{id, name}`), so this optimizes for a clean, copyable shape.

## Changes

- **`lib/admin/server-fn.ts`** (additive): export `adminFetchRaw(path, init)` — a non-throwing authed fetch that returns the raw `Response`. `adminFetch` now delegates to it, then applies the existing throw-on-non-2xx. This is the reusable primitive every entity's `delete*` needs to surface the `409 {dependents}` body that `adminFetch` would otherwise collapse into an opaque `Error`. `NAV_ITEMS` is untouched.
- **`lib/admin/styles.ts`** (new): `listStyles`/`createStyle`/`updateStyle`/`deleteStyle` server fns + the pure, exported `parseDeleteResult(status, body)` mapper (`200 → {ok:true}`, `409 → {ok:false, dependents}`, other non-2xx → throw). Local `Style` type — `apps/www` does not depend on `@domain`.
- **`routes/admin/styles.tsx`** (new): `createFileRoute('/admin/styles')`. TanStack Query list → `<DataTable>` (single Name column, client filter), `<EntityForm>` modal for create/edit, `<ConfirmDelete>` wired to the 409 dependents path. Discriminated-union form state.
- **`tests/lib/admin/styles.test.ts`** (new): `parseDeleteResult` cases (200, 409 with/without dependents, other → throws).

## Notes

- The installed `@tanstack/start-client-core@1.170` renames the builder method `.validator()` → `.inputValidator()`; used the real API.
- The plan's brief said DELETE returns 204; the real route returns `200 {ok:true}` — coded to the real route.

## Verification

- `bun run typecheck` — passes across all packages.
- `bun test` — 106 pass / 0 fail, including the 4 new `parseDeleteResult` cases.
- Live UI exercise (criteria 3–8) requires a running API + Postgres, not available in this worktree; the data-flow logic (`parseDeleteResult`, query wiring) is covered by typecheck + unit tests.
- `NAV_ITEMS` (`components/admin/nav.ts`) and `routes/admin/route.tsx` are unchanged (`git diff --stat` shows only `server-fn.ts`).