### PR TITLE
feat(www): breweries admin CRUD page

### DIFF
--- a/apps/www/src/lib/admin/breweries.ts
+++ b/apps/www/src/lib/admin/breweries.ts
@@ -1,0 +1,69 @@
+import {createServerFn} from '@tanstack/react-start';
+import {adminFetch} from './server-fn';
+
+export type Brewery = {id: number; name: string};
+
+export type DeleteResult = {ok: true} | {ok: false; dependents: Record<string, number>};
+
+// Pure mapping of the DELETE response (status + parsed body) to the DeleteResult
+// union. Exported so the 200/409 branching is testable without a network. The
+// 409 body shape is {error, dependents:{beers:<n>}} per the API contract.
+export function parseDeleteResult(status: number, body: unknown): DeleteResult {
+  if (status === 200) return {ok: true};
+
+  if (status === 409) {
+    const dependents =
+      body && typeof body === 'object' && 'dependents' in body
+        ? ((body as {dependents: Record<string, number>}).dependents ?? {})
+        : {};
+    return {ok: false, dependents};
+  }
+
+  throw new Error(`Admin API delete failed: ${status} — ${JSON.stringify(body)}`);
+}
+
+export const listBreweries = createServerFn({method: 'GET'}).handler(async () => {
+  const res = await adminFetch('/admin/breweries');
+  return (await res.json()) as Brewery[];
+});
+
+export const createBrewery = createServerFn({method: 'POST'})
+  .inputValidator((d: {name: string}) => d)
+  .handler(async ({data}) => {
+    const res = await adminFetch('/admin/breweries', {
+      method: 'POST',
+      body: JSON.stringify({name: data.name}),
+    });
+    return (await res.json()) as Brewery;
+  });
+
+export const updateBrewery = createServerFn({method: 'POST'})
+  .inputValidator((d: {id: number; name: string}) => d)
+  .handler(async ({data}) => {
+    const res = await adminFetch(`/admin/breweries/${data.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({name: data.name}),
+    });
+    return (await res.json()) as Brewery;
+  });
+
+// Delete bypasses adminFetch (which throws on the 409) so the structured
+// `dependents` payload survives as data for ConfirmDelete. Env resolution mirrors
+// server-fn.ts; the ~handful of duplicated lines keep that shared file untouched.
+export const deleteBrewery = createServerFn({method: 'POST'})
+  .inputValidator((d: {id: number}) => d)
+  .handler(async ({data}): Promise<DeleteResult> => {
+    const baseUrl = process.env.API_URL ?? process.env.VITE_API_URL ?? 'http://localhost:3001';
+    const key = process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? '';
+
+    const res = await fetch(`${baseUrl}/admin/breweries/${data.id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+    });
+
+    const body = await res.json().catch(() => null);
+    return parseDeleteResult(res.status, body);
+  });

--- a/apps/www/src/routes/admin/breweries.tsx
+++ b/apps/www/src/routes/admin/breweries.tsx
@@ -33,7 +33,7 @@ type Editing = Brewery | 'new' | null;
 function BreweriesPage() {
   const queryClient = useQueryClient();
 
-  const {data: breweries = [], isLoading} = useQuery({
+  const {data: breweries = [], isLoading, isError} = useQuery({
     queryKey: QUERY_KEY,
     queryFn: () => listBreweries(),
   });
@@ -137,6 +137,8 @@ function BreweriesPage() {
 
       {isLoading ? (
         <p className="text-sm text-text-secondary">Loading…</p>
+      ) : isError ? (
+        <p className="text-sm text-red">Couldn’t load breweries. Try refreshing.</p>
       ) : (
         <DataTable
           columns={COLUMNS}

--- a/apps/www/src/routes/admin/breweries.tsx
+++ b/apps/www/src/routes/admin/breweries.tsx
@@ -1,0 +1,173 @@
+import {useCallback, useState} from 'react';
+import {createFileRoute} from '@tanstack/react-router';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {DataTable} from '../../components/admin/DataTable';
+import type {Column, RowAction} from '../../components/admin/DataTable';
+import {EntityForm} from '../../components/admin/EntityForm';
+import type {FieldDef} from '../../components/admin/EntityForm';
+import {ConfirmDelete} from '../../components/admin/ConfirmDelete';
+import {
+  createBrewery,
+  deleteBrewery,
+  listBreweries,
+  updateBrewery,
+} from '../../lib/admin/breweries';
+import type {Brewery} from '../../lib/admin/breweries';
+
+export const Route = createFileRoute('/admin/breweries')({
+  head: () => ({
+    meta: [{title: 'PghBeer — Breweries'}],
+  }),
+  component: BreweriesPage,
+});
+
+const QUERY_KEY = ['admin', 'breweries'] as const;
+
+const COLUMNS: Column<Brewery>[] = [{id: 'name', header: 'Name', accessor: (row) => row.name}];
+
+const FIELDS: FieldDef[] = [{name: 'name', label: 'Name', type: 'text', required: true}];
+
+// 'new' = the create form; a Brewery = editing that row; null = no form open.
+type Editing = Brewery | 'new' | null;
+
+function BreweriesPage() {
+  const queryClient = useQueryClient();
+
+  const {data: breweries = [], isLoading} = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => listBreweries(),
+  });
+
+  const [editing, setEditing] = useState<Editing>(null);
+  const [name, setName] = useState('');
+  const [deleting, setDeleting] = useState<Brewery | null>(null);
+  const [deleteDependents, setDeleteDependents] = useState<Record<string, number> | undefined>(
+    undefined,
+  );
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({queryKey: QUERY_KEY}),
+    [queryClient],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (next: string) => createBrewery({data: {name: next}}),
+    onSuccess: () => {
+      invalidate();
+      closeForm();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (vars: {id: number; name: string}) => updateBrewery({data: vars}),
+    onSuccess: () => {
+      invalidate();
+      closeForm();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteBrewery({data: {id}}),
+    onSuccess: (result) => {
+      if (result.ok) {
+        invalidate();
+        closeDelete();
+      } else {
+        setDeleteDependents(result.dependents);
+      }
+    },
+  });
+
+  function closeForm() {
+    setEditing(null);
+    setName('');
+  }
+
+  function closeDelete() {
+    setDeleting(null);
+    setDeleteDependents(undefined);
+  }
+
+  const openCreate = useCallback(() => {
+    setEditing('new');
+    setName('');
+  }, []);
+
+  const openEdit = useCallback((row: Brewery) => {
+    setEditing(row);
+    setName(row.name);
+  }, []);
+
+  const openDelete = useCallback((row: Brewery) => {
+    setDeleting(row);
+    setDeleteDependents(undefined);
+  }, []);
+
+  const actions = useCallback(
+    (): RowAction<Brewery>[] => [
+      {label: 'Edit', onClick: openEdit},
+      {label: 'Delete', variant: 'danger', onClick: openDelete},
+    ],
+    [openEdit, openDelete],
+  );
+
+  function handleSubmit() {
+    const trimmed = name.trim();
+    if (trimmed === '') return;
+
+    if (editing === 'new') {
+      createMutation.mutate(trimmed);
+    } else if (editing) {
+      updateMutation.mutate({id: editing.id, name: trimmed});
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-2xl font-bold text-gold">Breweries</h1>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-check-fg"
+        >
+          New brewery
+        </button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-text-secondary">Loading…</p>
+      ) : (
+        <DataTable
+          columns={COLUMNS}
+          rows={breweries}
+          getRowId={(row) => row.id}
+          actions={actions}
+          filterPlaceholder="Filter breweries…"
+          emptyMessage="No breweries yet."
+        />
+      )}
+
+      {editing ? (
+        <EntityForm
+          fields={FIELDS}
+          values={{name}}
+          onChange={(_, value) => setName(typeof value === 'string' ? value : '')}
+          onSubmit={handleSubmit}
+          onCancel={closeForm}
+          submitLabel={editing === 'new' ? 'Create' : 'Save'}
+        />
+      ) : null}
+
+      <ConfirmDelete
+        open={deleting !== null}
+        title="Delete brewery?"
+        message={deleting ? `Delete "${deleting.name}"? This action cannot be undone.` : undefined}
+        dependents={deleteDependents}
+        onConfirm={() => deleting && deleteMutation.mutate(deleting.id)}
+        onCancel={closeDelete}
+        confirming={deleteMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/www/tests/lib/admin/breweries.test.ts
+++ b/apps/www/tests/lib/admin/breweries.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'bun:test';
+
+import {parseDeleteResult} from '../../../src/lib/admin/breweries';
+
+describe('parseDeleteResult', function () {
+  it('should return {ok:true} for a 200 success', function () {
+    expect(parseDeleteResult(200, {ok: true})).toEqual({ok: true});
+  });
+
+  it('should surface dependents for a 409 blocked delete', function () {
+    const body = {error: 'has dependents', dependents: {beers: 3}};
+
+    expect(parseDeleteResult(409, body)).toEqual({
+      ok: false,
+      dependents: {beers: 3},
+    });
+  });
+
+  it('should default dependents to {} when a 409 body omits them', function () {
+    expect(parseDeleteResult(409, {error: 'has dependents'})).toEqual({
+      ok: false,
+      dependents: {},
+    });
+  });
+
+  it('should throw on an unexpected status', function () {
+    expect(() => parseDeleteResult(500, {error: 'boom'})).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the www-side Breweries management page at `/admin/breweries`, wiring the shared admin components (`DataTable`, `EntityForm`, `ConfirmDelete`) to TanStack Query against the live `/admin/breweries*` API contract.

- **`lib/admin/breweries.ts`** — four `createServerFn` wrappers (`listBreweries`, `createBrewery`, `updateBrewery`, `deleteBrewery`) plus the `Brewery` / `DeleteResult` types. List/create/update use `adminFetch`. `deleteBrewery` does a raw `DELETE` (env resolution mirrors `server-fn.ts`) so the `409 {dependents}` payload survives as structured data instead of being thrown away by `adminFetch`'s non-2xx throw. `parseDeleteResult(status, body)` is extracted as a pure, exported helper and unit-tested.
- **`routes/admin/breweries.tsx`** — `createFileRoute('/admin/breweries')` client route: a `DataTable` (Name column + client filter), a "New brewery" button, a create/edit `EntityForm` modal, and a `ConfirmDelete` that flips to the blocked "used by N beers" message on a 409. All three mutations invalidate `['admin','breweries']`.
- **`tests/lib/admin/breweries.test.ts`** — black-box tests for `parseDeleteResult` (200 → `{ok:true}`, 409 → `{ok:false, dependents}`, missing-dependents default, throw on unexpected status).

## Verification

- `bun run typecheck` — clean across all packages.
- `bun test` — 106 pass / 0 fail (4 new in `breweries.test.ts`).
- Scope: only `apps/www/**` touched; `NAV_ITEMS` unchanged; no `apps/api`/`packages/domain`/`server-fn.ts` edits (Option A).

## Notes

- `createServerFn` v1.168 here exposes `.inputValidator()` (not `.validator()`), used per the plan's fallback.
- `routeTree.gen.ts` is gitignored and regenerated by the Vite plugin on dev/build — not committed.