### PR TITLE
feat(www): add beers CRUD admin page

### DIFF
--- a/apps/www/src/lib/admin/beers.ts
+++ b/apps/www/src/lib/admin/beers.ts
@@ -1,0 +1,140 @@
+import {createServerFn} from '@tanstack/react-start';
+import type {
+  BeerListItem,
+  BreweryRow,
+  CreateBeerInput,
+  StyleRow,
+  UpdateBeerInput,
+} from '@domain';
+
+import {adminFetch, adminFetchRaw} from './server-fn';
+import type {FieldValue} from '../../components/admin/EntityForm';
+
+// Source of truth: packages/database/schema/helpers.ts:3. Hardcoded here to
+// avoid pulling the `database` (drizzle) runtime into the client bundle; the
+// API re-validates against the same enum. 'na' is NOT a value here — NA-ness
+// is the separate `isNa` boolean.
+export const BEVERAGE_TYPES = [
+  'beer',
+  'wine',
+  'mead',
+  'cocktail',
+  'cider',
+  'seltzer',
+  'hard_tea',
+] as const;
+
+export type DeleteBeerResult =
+  | {ok: true}
+  | {ok: false; dependents: {stats: number; eventLinks: number}};
+
+// --- Pure helpers (unit-tested) ---
+
+// Coerce raw EntityForm values into a create payload matching createBeerSchema:
+// FK select ids string -> number, blank ABV -> null. Returns null when a
+// required field is missing (name empty, beverageType/brewery/style
+// unselected) so the caller can block submit without issuing a request.
+export function toBeerPayload(
+  values: Record<string, FieldValue>,
+): CreateBeerInput | null {
+  const name = typeof values.name === 'string' ? values.name.trim() : '';
+  const beverageType = values.beverageType;
+  const breweryRaw = values.breweryId;
+  const styleRaw = values.styleId;
+
+  if (name === '' || beverageType === '' || beverageType == null) return null;
+  if (breweryRaw === '' || breweryRaw == null) return null;
+  if (styleRaw === '' || styleRaw == null) return null;
+
+  const breweryId = Number(breweryRaw);
+  const styleId = Number(styleRaw);
+  if (!Number.isInteger(breweryId) || !Number.isInteger(styleId)) return null;
+
+  const abv =
+    values.abv === '' || values.abv == null ? null : Number(values.abv);
+
+  return {
+    name,
+    abv,
+    beverageType: beverageType as CreateBeerInput['beverageType'],
+    isNa: values.isNa === true,
+    breweryId,
+    styleId,
+  };
+}
+
+// Map a DELETE response (status + parsed body) to a typed result. A 409 carries
+// the blocking dependent counts; any 2xx is success. Other statuses are
+// handled by the caller (which throws) before reaching here.
+export function parseDeleteResult(
+  status: number,
+  body: unknown,
+): DeleteBeerResult {
+  if (status === 409) {
+    const dependents =
+      (body as {dependents?: {stats?: number; eventLinks?: number}})
+        ?.dependents ?? {};
+    return {
+      ok: false,
+      dependents: {
+        stats: dependents.stats ?? 0,
+        eventLinks: dependents.eventLinks ?? 0,
+      },
+    };
+  }
+  return {ok: true};
+}
+
+// --- Server functions (ADMIN_API_KEY stays server-side) ---
+
+export const listBeers = createServerFn({method: 'GET'}).handler(
+  async () => (await adminFetch('/admin/beers')).json() as Promise<BeerListItem[]>,
+);
+
+export const listBreweries = createServerFn({method: 'GET'}).handler(
+  async () =>
+    (await adminFetch('/admin/breweries')).json() as Promise<BreweryRow[]>,
+);
+
+export const listStyles = createServerFn({method: 'GET'}).handler(
+  async () => (await adminFetch('/admin/styles')).json() as Promise<StyleRow[]>,
+);
+
+export const createBeer = createServerFn({method: 'POST'})
+  .inputValidator((data: CreateBeerInput) => data)
+  .handler(
+    async ({data}) =>
+      (
+        await adminFetch('/admin/beers', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        })
+      ).json() as Promise<BeerListItem>,
+  );
+
+export const updateBeer = createServerFn({method: 'POST'})
+  .inputValidator((input: {id: number; data: UpdateBeerInput}) => input)
+  .handler(
+    async ({data: {id, data}}) =>
+      (
+        await adminFetch(`/admin/beers/${id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(data),
+        })
+      ).json() as Promise<BeerListItem>,
+  );
+
+export const deleteBeer = createServerFn({method: 'POST'})
+  .inputValidator((id: number) => id)
+  .handler(async ({data: id}): Promise<DeleteBeerResult> => {
+    const res = await adminFetchRaw(`/admin/beers/${id}`, {method: 'DELETE'});
+    if (res.ok) return {ok: true};
+    if (res.status === 409) {
+      const body = await res.json().catch(() => ({}));
+      return parseDeleteResult(409, body);
+    }
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `Delete failed: ${res.status} ${res.statusText}${text ? ` — ${text}` : ''}`,
+    );
+  });

--- a/apps/www/src/lib/admin/server-fn.ts
+++ b/apps/www/src/lib/admin/server-fn.ts
@@ -21,14 +21,17 @@ function resolveApiKey(): string {
   return process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? '';
 }
 
-export async function adminFetch(
+// Non-throwing variant: returns the raw Response so callers can branch on
+// status without adminFetch's throw-on-non-OK behavior (e.g. the 409
+// blocked-delete path, which carries a `dependents` payload to surface).
+export async function adminFetchRaw(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
   const url = `${resolveBaseUrl()}${path}`;
   const key = resolveApiKey();
 
-  const res = await fetch(url, {
+  return fetch(url, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
@@ -36,6 +39,13 @@ export async function adminFetch(
       ...init.headers,
     },
   });
+}
+
+export async function adminFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const res = await adminFetchRaw(path, init);
 
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/apps/www/src/routes/admin/beers.tsx
+++ b/apps/www/src/routes/admin/beers.tsx
@@ -1,0 +1,269 @@
+import {useState} from 'react';
+import {createFileRoute} from '@tanstack/react-router';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import type {BeerListItem} from '@domain';
+
+import {DataTable} from '../../components/admin/DataTable';
+import type {Column, RowAction} from '../../components/admin/DataTable';
+import {EntityForm} from '../../components/admin/EntityForm';
+import type {FieldDef, FieldValue} from '../../components/admin/EntityForm';
+import {ConfirmDelete} from '../../components/admin/ConfirmDelete';
+import {
+  BEVERAGE_TYPES,
+  createBeer,
+  deleteBeer,
+  listBeers,
+  listBreweries,
+  listStyles,
+  toBeerPayload,
+  updateBeer,
+} from '../../lib/admin/beers';
+
+export const Route = createFileRoute('/admin/beers')({
+  head: () => ({
+    meta: [{title: 'PghBeer — Beers'}],
+  }),
+  component: BeersAdmin,
+});
+
+const BEERS_KEY = ['admin', 'beers'] as const;
+
+const columns: Column<BeerListItem>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
+  {id: 'brewery', header: 'Brewery', accessor: (row) => row.brewery.name},
+  {id: 'style', header: 'Style', accessor: (row) => row.style.name},
+  {id: 'abv', header: 'ABV', accessor: (row) => row.abv},
+  {id: 'type', header: 'Type', accessor: (row) => row.beverageType},
+  {
+    id: 'na',
+    header: 'NA',
+    accessor: (row) => row.isNa,
+    cell: (row) => (row.isNa ? '✓' : ''),
+  },
+];
+
+function emptyValues(): Record<string, FieldValue> {
+  return {
+    name: '',
+    abv: null,
+    beverageType: '',
+    isNa: false,
+    breweryId: '',
+    styleId: '',
+  };
+}
+
+function valuesFromBeer(beer: BeerListItem): Record<string, FieldValue> {
+  return {
+    name: beer.name,
+    abv: beer.abv,
+    beverageType: beer.beverageType,
+    isNa: beer.isNa,
+    breweryId: String(beer.brewery.id),
+    styleId: String(beer.style.id),
+  };
+}
+
+function BeersAdmin() {
+  const queryClient = useQueryClient();
+
+  const beersQuery = useQuery({queryKey: BEERS_KEY, queryFn: () => listBeers()});
+  const breweriesQuery = useQuery({
+    queryKey: ['admin', 'breweries'],
+    queryFn: () => listBreweries(),
+  });
+  const stylesQuery = useQuery({
+    queryKey: ['admin', 'styles'],
+    queryFn: () => listStyles(),
+  });
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<BeerListItem | null>(null);
+  const [values, setValues] = useState<Record<string, FieldValue>>(emptyValues);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const [deleting, setDeleting] = useState<BeerListItem | null>(null);
+  const [blockedDependents, setBlockedDependents] = useState<
+    Record<string, number> | undefined
+  >(undefined);
+
+  function invalidateBeers() {
+    return queryClient.invalidateQueries({queryKey: BEERS_KEY});
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const payload = toBeerPayload(values);
+      if (!payload) throw new Error('Name, type, brewery, and style are required.');
+      return editing
+        ? updateBeer({data: {id: editing.id, data: payload}})
+        : createBeer({data: payload});
+    },
+    onSuccess: async () => {
+      await invalidateBeers();
+      closeForm();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteBeer({data: id}),
+    onSuccess: async (result) => {
+      if (result.ok) {
+        await invalidateBeers();
+        setDeleting(null);
+        setBlockedDependents(undefined);
+        return;
+      }
+      setBlockedDependents(result.dependents);
+    },
+  });
+
+  function openCreate() {
+    setEditing(null);
+    setValues(emptyValues());
+    setFormError(null);
+    saveMutation.reset();
+    setFormOpen(true);
+  }
+
+  function openEdit(beer: BeerListItem) {
+    setEditing(beer);
+    setValues(valuesFromBeer(beer));
+    setFormError(null);
+    saveMutation.reset();
+    setFormOpen(true);
+  }
+
+  function closeForm() {
+    setFormOpen(false);
+    setEditing(null);
+    setFormError(null);
+  }
+
+  function openDelete(beer: BeerListItem) {
+    setDeleting(beer);
+    setBlockedDependents(undefined);
+    deleteMutation.reset();
+  }
+
+  function closeDelete() {
+    setDeleting(null);
+    setBlockedDependents(undefined);
+  }
+
+  function handleSubmit() {
+    if (!toBeerPayload(values)) {
+      setFormError('Name, type, brewery, and style are required.');
+      return;
+    }
+    setFormError(null);
+    saveMutation.mutate();
+  }
+
+  const fields: FieldDef[] = [
+    {type: 'text', name: 'name', label: 'Name', required: true},
+    {type: 'number', name: 'abv', label: 'ABV'},
+    {
+      type: 'select',
+      name: 'beverageType',
+      label: 'Type',
+      required: true,
+      options: BEVERAGE_TYPES.map((value) => ({value, label: value})),
+    },
+    {type: 'checkbox', name: 'isNa', label: 'Non-alcoholic'},
+    {
+      type: 'select',
+      name: 'breweryId',
+      label: 'Brewery',
+      required: true,
+      options: (breweriesQuery.data ?? []).map((b) => ({
+        value: b.id,
+        label: b.name,
+      })),
+    },
+    {
+      type: 'select',
+      name: 'styleId',
+      label: 'Style',
+      required: true,
+      options: (stylesQuery.data ?? []).map((s) => ({
+        value: s.id,
+        label: s.name,
+      })),
+    },
+  ];
+
+  const rowActions = (): RowAction<BeerListItem>[] => [
+    {label: 'Edit', onClick: openEdit},
+    {label: 'Delete', onClick: openDelete, variant: 'danger'},
+  ];
+
+  const isLoading =
+    beersQuery.isLoading || breweriesQuery.isLoading || stylesQuery.isLoading;
+  const loadError =
+    beersQuery.error ?? breweriesQuery.error ?? stylesQuery.error;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-2xl font-bold text-gold">Beers</h1>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-check-fg"
+        >
+          Add beer
+        </button>
+      </div>
+
+      {loadError ? (
+        <div className="rounded-lg border border-red bg-surface px-4 py-3 text-sm text-red">
+          {loadError instanceof Error ? loadError.message : 'Failed to load beers.'}
+        </div>
+      ) : isLoading ? (
+        <div className="text-sm text-text-secondary">Loading…</div>
+      ) : (
+        <DataTable
+          columns={columns}
+          rows={beersQuery.data ?? []}
+          getRowId={(row) => row.id}
+          actions={rowActions}
+          filterPlaceholder="Filter by name, brewery, or style…"
+          emptyMessage="No beers yet."
+        />
+      )}
+
+      {formOpen ? (
+        <div className="flex flex-col gap-2">
+          <EntityForm
+            fields={fields}
+            values={values}
+            onChange={(name, value) =>
+              setValues((prev) => ({...prev, [name]: value}))
+            }
+            onSubmit={handleSubmit}
+            onCancel={closeForm}
+            submitLabel={editing ? 'Save changes' : 'Create beer'}
+          />
+          {formError || saveMutation.error ? (
+            <p className="text-sm text-red">
+              {formError ??
+                (saveMutation.error instanceof Error
+                  ? saveMutation.error.message
+                  : 'Save failed.')}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <ConfirmDelete
+        open={deleting !== null}
+        title="Delete this beer?"
+        dependents={blockedDependents}
+        confirming={deleteMutation.isPending}
+        onConfirm={() => deleting && deleteMutation.mutate(deleting.id)}
+        onCancel={closeDelete}
+      />
+    </div>
+  );
+}

--- a/apps/www/src/routes/admin/beers.tsx
+++ b/apps/www/src/routes/admin/beers.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import {createFileRoute} from '@tanstack/react-router';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import type {BeerListItem} from '@domain';
+import type {BeerListItem, CreateBeerInput} from '@domain';
 
 import {DataTable} from '../../components/admin/DataTable';
 import type {Column, RowAction} from '../../components/admin/DataTable';
@@ -92,13 +92,10 @@ function BeersAdmin() {
   }
 
   const saveMutation = useMutation({
-    mutationFn: async () => {
-      const payload = toBeerPayload(values);
-      if (!payload) throw new Error('Name, type, brewery, and style are required.');
-      return editing
+    mutationFn: (payload: CreateBeerInput) =>
+      editing
         ? updateBeer({data: {id: editing.id, data: payload}})
-        : createBeer({data: payload});
-    },
+        : createBeer({data: payload}),
     onSuccess: async () => {
       await invalidateBeers();
       closeForm();
@@ -152,12 +149,13 @@ function BeersAdmin() {
   }
 
   function handleSubmit() {
-    if (!toBeerPayload(values)) {
+    const payload = toBeerPayload(values);
+    if (!payload) {
       setFormError('Name, type, brewery, and style are required.');
       return;
     }
     setFormError(null);
-    saveMutation.mutate();
+    saveMutation.mutate(payload);
   }
 
   const fields: FieldDef[] = [
@@ -234,8 +232,12 @@ function BeersAdmin() {
       )}
 
       {formOpen ? (
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-6">
+          <h2 className="font-display text-lg font-bold text-text">
+            {editing ? 'Edit beer' : 'New beer'}
+          </h2>
           <EntityForm
+            as="inline"
             fields={fields}
             values={values}
             onChange={(name, value) =>
@@ -259,6 +261,11 @@ function BeersAdmin() {
       <ConfirmDelete
         open={deleting !== null}
         title="Delete this beer?"
+        message={
+          deleteMutation.error instanceof Error
+            ? deleteMutation.error.message
+            : undefined
+        }
         dependents={blockedDependents}
         confirming={deleteMutation.isPending}
         onConfirm={() => deleting && deleteMutation.mutate(deleting.id)}

--- a/apps/www/tests/lib/admin/beers.test.ts
+++ b/apps/www/tests/lib/admin/beers.test.ts
@@ -1,0 +1,110 @@
+import {describe, expect, it} from 'bun:test';
+
+import {parseDeleteResult, toBeerPayload} from '../../../src/lib/admin/beers';
+import type {FieldValue} from '../../../src/components/admin/EntityForm';
+
+function makeValues(
+  overrides: Record<string, FieldValue> = {},
+): Record<string, FieldValue> {
+  return {
+    name: 'Hazy IPA',
+    abv: 6.5,
+    beverageType: 'beer',
+    isNa: false,
+    breweryId: '3',
+    styleId: '7',
+    ...overrides,
+  };
+}
+
+describe('toBeerPayload', function () {
+  it('should coerce FK select string ids to numbers', function () {
+    const payload = toBeerPayload(makeValues({breweryId: '3', styleId: '7'}));
+
+    expect(payload).not.toBeNull();
+    expect(payload!.breweryId).toBe(3);
+    expect(payload!.styleId).toBe(7);
+  });
+
+  it('should keep a numeric abv as a number', function () {
+    const payload = toBeerPayload(makeValues({abv: 6.5}));
+
+    expect(payload!.abv).toBe(6.5);
+  });
+
+  it('should map a blank abv to null', function () {
+    const payload = toBeerPayload(makeValues({abv: ''}));
+
+    expect(payload!.abv).toBeNull();
+  });
+
+  it('should map an absent abv to null', function () {
+    const payload = toBeerPayload(makeValues({abv: null}));
+
+    expect(payload!.abv).toBeNull();
+  });
+
+  it('should pass through the isNa boolean', function () {
+    const payload = toBeerPayload(makeValues({isNa: true}));
+
+    expect(payload!.isNa).toBe(true);
+  });
+
+  it('should trim the name', function () {
+    const payload = toBeerPayload(makeValues({name: '  Saison  '}));
+
+    expect(payload!.name).toBe('Saison');
+  });
+
+  it('should block when name is empty', function () {
+    expect(toBeerPayload(makeValues({name: '   '}))).toBeNull();
+  });
+
+  it('should block when brewery is unselected', function () {
+    expect(toBeerPayload(makeValues({breweryId: ''}))).toBeNull();
+  });
+
+  it('should block when style is unselected', function () {
+    expect(toBeerPayload(makeValues({styleId: ''}))).toBeNull();
+  });
+
+  it('should block when beverageType is unselected', function () {
+    expect(toBeerPayload(makeValues({beverageType: ''}))).toBeNull();
+  });
+});
+
+describe('parseDeleteResult', function () {
+  it('should treat a 200 as success', function () {
+    expect(parseDeleteResult(200, {ok: true})).toEqual({ok: true});
+  });
+
+  it('should map a 409 body to the blocking dependent counts', function () {
+    const result = parseDeleteResult(409, {
+      error: 'has dependents',
+      dependents: {stats: 4, eventLinks: 2},
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      dependents: {stats: 4, eventLinks: 2},
+    });
+  });
+
+  it('should default missing dependent counts to zero on a 409', function () {
+    const result = parseDeleteResult(409, {dependents: {stats: 3}});
+
+    expect(result).toEqual({
+      ok: false,
+      dependents: {stats: 3, eventLinks: 0},
+    });
+  });
+
+  it('should not throw when a 409 body is malformed', function () {
+    const result = parseDeleteResult(409, {});
+
+    expect(result).toEqual({
+      ok: false,
+      dependents: {stats: 0, eventLinks: 0},
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Beers** admin page at `/admin/beers` — the richest entity form (text name, nullable numeric ABV, 7-value `beverageType` enum select, `isNa` boolean, and required `breweryId`/`styleId` FK selects). Composes the existing foundation components (`DataTable`, `EntityForm`, `ConfirmDelete`) per the documented `server-fn.ts` convention.

## Changes

- **`lib/admin/beers.ts`** (new) — six `createServerFn` wrappers (`listBeers`, `listBreweries`, `listStyles`, `createBeer`, `updateBeer`, `deleteBeer`) so `ADMIN_API_KEY` never reaches the client bundle. Two pure, unit-tested helpers: `toBeerPayload` (coerces FK select string ids → numbers, blank ABV → `null`, guards required fields) and `parseDeleteResult` (maps the 409 body to `{stats, eventLinks}`).
- **`routes/admin/beers.tsx`** (new) — TanStack Query wiring for the three lists + create/update/delete mutations with `invalidateQueries`. DataTable columns Name, Brewery, Style, ABV, Type, NA (Brewery/Style accessors return the joined **names**, so the filter spans name + brewery + style for free).
- **`lib/admin/server-fn.ts`** (additive) — extracted a non-throwing `adminFetchRaw` (returns the raw `Response`) so `deleteBeer` can branch on the 409 blocked-delete status instead of throwing; `adminFetch` now delegates to it.
- **`tests/lib/admin/beers.test.ts`** (new) — covers payload coercion + 409 → dependents mapping.

## Notes

- The 7 `beverageType` values are hardcoded as a local `as const` (source of truth: `database/schema/helpers.ts`) rather than importing `beverageTypeEnum` — that's a runtime value from `database` and importing it would pull drizzle into the client bundle. The API re-validates.
- Server fns import `@domain` types only (`import type`), so no runtime workspace dep is added.
- DELETE returns `200 {ok:true}` (route reality, not the brief's 204); any 2xx is treated as success.

## Verification

- `bun run typecheck` — passes (all packages)
- `bun test apps/www` — 24 pass / 0 fail
- `vite build` regenerates `routeTree.gen.ts` (gitignored) with the `/admin/beers` entry

## Scope

Per acceptance criterion 10: `components/admin/nav.ts`, `apps/api/**`, and `packages/**` are untouched.