### PR TITLE
feat(www): admin events CRUD + per-event beer-list manager

### DIFF
--- a/apps/www/src/lib/admin/events.ts
+++ b/apps/www/src/lib/admin/events.ts
@@ -1,0 +1,135 @@
+// SERVER-ONLY module. Every server function here runs inside createServerFn,
+// so the admin API key (read via adminFetch / process.env) stays server-side
+// and is never bundled to the client. Do not import this into client-only code
+// except to call the exported server functions (which marshal across the
+// boundary) or the pure parseDeleteResponse helper.
+
+import {createServerFn} from '@tanstack/react-start';
+import {adminFetch} from './server-fn';
+
+// Minimal row shapes mirroring @domain's EventRow / BeerListItem. The www app
+// does not depend on @domain (avoids a workspace dep), so they are redeclared
+// here in the lib/types.ts style.
+export type EventRow = {
+  id: number;
+  name: string;
+  date: string;
+};
+
+export type AdminBeer = {
+  id: number;
+  name: string;
+  abv: number | null;
+  beverageType: string;
+  isNa: boolean;
+  brewery: {id: number; name: string};
+  style: {id: number; name: string};
+};
+
+export type DeleteEventResult =
+  | {ok: true}
+  | {ok: false; dependents: Record<string, number>};
+
+// Pure, exported for unit testing without the Start runtime. Maps a delete
+// response (status + parsed body) to the typed result. Any 2xx is success; a
+// non-2xx carries the dependents map if present, else an empty map.
+export function parseDeleteResponse(
+  status: number,
+  body: unknown,
+): DeleteEventResult {
+  if (status >= 200 && status < 300) return {ok: true};
+
+  const dependents =
+    body !== null &&
+    typeof body === 'object' &&
+    'dependents' in body &&
+    typeof (body as {dependents: unknown}).dependents === 'object' &&
+    (body as {dependents: unknown}).dependents !== null
+      ? ((body as {dependents: Record<string, number>}).dependents)
+      : {};
+
+  return {ok: false, dependents};
+}
+
+export const listEvents = createServerFn({method: 'GET'}).handler(
+  async (): Promise<EventRow[]> => (await adminFetch('/admin/events')).json(),
+);
+
+export const createEvent = createServerFn({method: 'POST'})
+  .inputValidator((input: {name: string; date: string}) => input)
+  .handler(
+    async ({data}): Promise<EventRow> =>
+      (
+        await adminFetch('/admin/events', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        })
+      ).json(),
+  );
+
+export const updateEvent = createServerFn({method: 'POST'})
+  // Schema rejects partial updates — always send both name and date.
+  .inputValidator((input: {id: number; name: string; date: string}) => input)
+  .handler(
+    async ({data}): Promise<EventRow> =>
+      (
+        await adminFetch(`/admin/events/${data.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({name: data.name, date: data.date}),
+        })
+      ).json(),
+  );
+
+// Raw fetch (not adminFetch): adminFetch throws on every non-2xx, discarding
+// the structured 409 dependents payload. Replicate the ~2 lines of env
+// resolution inline and branch via parseDeleteResponse.
+export const deleteEvent = createServerFn({method: 'POST'})
+  .inputValidator((input: {id: number}) => input)
+  .handler(async ({data}): Promise<DeleteEventResult> => {
+    const baseUrl =
+      process.env.API_URL ??
+      process.env.VITE_API_URL ??
+      'http://localhost:3001';
+    const key = process.env.ADMIN_API_KEY ?? process.env.API_KEY ?? '';
+
+    const res = await fetch(`${baseUrl}/admin/events/${data.id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+    });
+
+    const body = await res.json().catch(() => null);
+    return parseDeleteResponse(res.status, body);
+  });
+
+export const listBeersForEvent = createServerFn({method: 'GET'})
+  .inputValidator((input: {eventId: number}) => input)
+  .handler(
+    async ({data}): Promise<AdminBeer[]> =>
+      (await adminFetch(`/admin/events/${data.eventId}/beers`)).json(),
+  );
+
+export const addBeerToEvent = createServerFn({method: 'POST'})
+  .inputValidator((input: {eventId: number; beerId: number}) => input)
+  .handler(async ({data}): Promise<{ok: true}> => {
+    await adminFetch(`/admin/events/${data.eventId}/beers`, {
+      method: 'POST',
+      body: JSON.stringify({beerId: data.beerId}),
+    });
+    return {ok: true};
+  });
+
+export const removeBeerFromEvent = createServerFn({method: 'POST'})
+  .inputValidator((input: {eventId: number; beerId: number}) => input)
+  .handler(async ({data}): Promise<{ok: true}> => {
+    await adminFetch(`/admin/events/${data.eventId}/beers/${data.beerId}`, {
+      method: 'DELETE',
+    });
+    return {ok: true};
+  });
+
+export const listBeers = createServerFn({method: 'GET'}).handler(
+  async (): Promise<AdminBeer[]> => (await adminFetch('/admin/beers')).json(),
+);

--- a/apps/www/src/lib/admin/events.ts
+++ b/apps/www/src/lib/admin/events.ts
@@ -31,13 +31,20 @@ export type DeleteEventResult =
   | {ok: false; dependents: Record<string, number>};
 
 // Pure, exported for unit testing without the Start runtime. Maps a delete
-// response (status + parsed body) to the typed result. Any 2xx is success; a
-// non-2xx carries the dependents map if present, else an empty map.
+// response (status + parsed body) to the typed result. Any 2xx is success; 409
+// is the dependents-block case (carrying its map if present, else empty). Any
+// other status is a genuine error — throw rather than masquerade it as a benign
+// empty-dependents block, which the UI would render as a silent no-op.
 export function parseDeleteResponse(
   status: number,
   body: unknown,
 ): DeleteEventResult {
   if (status >= 200 && status < 300) return {ok: true};
+
+  if (status !== 409) {
+    const detail = typeof body === 'string' ? body : JSON.stringify(body);
+    throw new Error(`Delete failed: ${status}${detail ? ` — ${detail}` : ''}`);
+  }
 
   const dependents =
     body !== null &&

--- a/apps/www/src/routes/admin/events.tsx
+++ b/apps/www/src/routes/admin/events.tsx
@@ -88,22 +88,49 @@ function AdminEvents() {
     },
   });
 
+  const resetFormErrors = useCallback(() => {
+    createMutation.reset();
+    updateMutation.reset();
+  }, [createMutation, updateMutation]);
+
   const openCreate = useCallback(() => {
+    resetFormErrors();
     setValues({name: '', date: ''});
     setFormMode('create');
-  }, []);
+  }, [resetFormErrors]);
 
-  const openEdit = useCallback((row: EventRow) => {
-    setValues({name: row.name, date: row.date});
-    setFormMode({edit: row});
-  }, []);
+  const openEdit = useCallback(
+    (row: EventRow) => {
+      resetFormErrors();
+      setValues({name: row.name, date: row.date});
+      setFormMode({edit: row});
+    },
+    [resetFormErrors],
+  );
 
   const openManage = useCallback((row: EventRow) => setManaging(row), []);
 
-  const openDelete = useCallback((row: EventRow) => {
+  const openDelete = useCallback(
+    (row: EventRow) => {
+      deleteMutation.reset();
+      setDependents(undefined);
+      setDeleteTarget(row);
+    },
+    [deleteMutation],
+  );
+
+  const closeForm = useCallback(() => {
+    resetFormErrors();
+    setFormMode(null);
+  }, [resetFormErrors]);
+
+  const closeDelete = useCallback(() => {
+    deleteMutation.reset();
+    setDeleteTarget(null);
     setDependents(undefined);
-    setDeleteTarget(row);
-  }, []);
+  }, [deleteMutation]);
+
+  const formError = createMutation.error ?? updateMutation.error;
 
   const handleFieldChange = useCallback((name: string, value: FieldValue) => {
     setValues((prev) => ({...prev, [name]: value}));
@@ -161,14 +188,17 @@ function AdminEvents() {
       )}
 
       {formMode ? (
-        <EntityForm
-          fields={eventFields}
-          values={values}
-          onChange={handleFieldChange}
-          onSubmit={handleSubmit}
-          onCancel={() => setFormMode(null)}
-          submitLabel={formMode === 'create' ? 'Create' : 'Save'}
-        />
+        <>
+          <EntityForm
+            fields={eventFields}
+            values={values}
+            onChange={handleFieldChange}
+            onSubmit={handleSubmit}
+            onCancel={closeForm}
+            submitLabel={formMode === 'create' ? 'Create' : 'Save'}
+          />
+          <ErrorBanner error={formError} />
+        </>
       ) : null}
 
       <ConfirmDelete
@@ -177,11 +207,9 @@ function AdminEvents() {
         dependents={dependents}
         confirming={deleteMutation.isPending}
         onConfirm={handleConfirmDelete}
-        onCancel={() => {
-          setDeleteTarget(null);
-          setDependents(undefined);
-        }}
+        onCancel={closeDelete}
       />
+      {deleteTarget ? <ErrorBanner error={deleteMutation.error} /> : null}
 
       {managing ? (
         <BeerManager event={managing} onClose={() => setManaging(null)} />
@@ -190,10 +218,29 @@ function AdminEvents() {
   );
 }
 
+// Surfaces a failed write mutation. Rendered above modal overlays (z-[60]) so
+// the message is visible even while a form/confirm dialog is open.
+function ErrorBanner({error}: {error: unknown}) {
+  if (!error) return null;
+  const message = error instanceof Error ? error.message : 'Something went wrong.';
+  return (
+    <div
+      role="alert"
+      className="fixed left-1/2 top-4 z-[60] max-w-md -translate-x-1/2 rounded-lg border border-red bg-surface px-4 py-2 text-center text-sm text-red shadow-lg"
+    >
+      {message}
+    </div>
+  );
+}
+
 const linkedColumns: Column<AdminBeer>[] = [
   {id: 'name', header: 'Name', accessor: (row) => row.name},
   {id: 'brewery', header: 'Brewery', accessor: (row) => row.brewery.name},
   {id: 'style', header: 'Style', accessor: (row) => row.style.name},
+];
+
+const pickerColumns: Column<AdminBeer>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
 ];
 
 type BeerManagerProps = {
@@ -277,6 +324,9 @@ function BeerManager({event, onClose}: BeerManagerProps) {
 
         <section className="flex flex-col gap-2">
           <h3 className="text-sm font-semibold text-text-secondary">Linked beers</h3>
+          {removeMutation.isError ? (
+            <p className="text-sm text-red">Failed to remove beer.</p>
+          ) : null}
           {linked.isLoading ? (
             <p className="text-sm text-text-secondary">Loading…</p>
           ) : linked.isError ? (
@@ -295,6 +345,9 @@ function BeerManager({event, onClose}: BeerManagerProps) {
 
         <section className="flex flex-col gap-2">
           <h3 className="text-sm font-semibold text-text-secondary">Add a beer</h3>
+          {addMutation.isError ? (
+            <p className="text-sm text-red">Failed to add beer.</p>
+          ) : null}
           <input
             type="text"
             value={pickerQuery}
@@ -340,7 +393,3 @@ function BeerManager({event, onClose}: BeerManagerProps) {
     </div>
   );
 }
-
-const pickerColumns: Column<AdminBeer>[] = [
-  {id: 'name', header: 'Name', accessor: (row) => row.name},
-];

--- a/apps/www/src/routes/admin/events.tsx
+++ b/apps/www/src/routes/admin/events.tsx
@@ -1,0 +1,346 @@
+import {useCallback, useMemo, useState} from 'react';
+import {createFileRoute} from '@tanstack/react-router';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+import {
+  DataTable,
+  filterRows,
+  type Column,
+  type RowAction,
+} from '../../components/admin/DataTable';
+import {EntityForm, type FieldDef, type FieldValue} from '../../components/admin/EntityForm';
+import {ConfirmDelete} from '../../components/admin/ConfirmDelete';
+import {
+  addBeerToEvent,
+  createEvent,
+  deleteEvent,
+  listBeers,
+  listBeersForEvent,
+  listEvents,
+  removeBeerFromEvent,
+  updateEvent,
+  type AdminBeer,
+  type EventRow,
+} from '../../lib/admin/events';
+
+export const Route = createFileRoute('/admin/events')({
+  head: () => ({
+    meta: [{title: 'PghBeer — Events'}],
+  }),
+  component: AdminEvents,
+});
+
+const eventColumns: Column<EventRow>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
+  {id: 'date', header: 'Date', accessor: (row) => row.date},
+];
+
+// EntityForm has no native `date` field type; date is a free string matching
+// the API's `min(1)` contract, entered as text (YYYY-MM-DD).
+const eventFields: FieldDef[] = [
+  {name: 'name', label: 'Name', type: 'text', required: true},
+  {name: 'date', label: 'Date', type: 'text', required: true},
+];
+
+type FormMode = 'create' | {edit: EventRow} | null;
+
+function AdminEvents() {
+  const queryClient = useQueryClient();
+  const events = useQuery({queryKey: ['admin', 'events'], queryFn: () => listEvents()});
+
+  const [formMode, setFormMode] = useState<FormMode>(null);
+  const [values, setValues] = useState<Record<string, FieldValue>>({});
+  const [deleteTarget, setDeleteTarget] = useState<EventRow | null>(null);
+  const [dependents, setDependents] = useState<Record<string, number> | undefined>(undefined);
+  const [managing, setManaging] = useState<EventRow | null>(null);
+
+  const invalidateEvents = useCallback(
+    () => queryClient.invalidateQueries({queryKey: ['admin', 'events']}),
+    [queryClient],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (data: {name: string; date: string}) => createEvent({data}),
+    onSuccess: () => {
+      invalidateEvents();
+      setFormMode(null);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: {id: number; name: string; date: string}) => updateEvent({data}),
+    onSuccess: () => {
+      invalidateEvents();
+      setFormMode(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteEvent({data: {id}}),
+    onSuccess: (result) => {
+      if (result.ok) {
+        invalidateEvents();
+        setDeleteTarget(null);
+        setDependents(undefined);
+        return;
+      }
+      setDependents(result.dependents);
+    },
+  });
+
+  const openCreate = useCallback(() => {
+    setValues({name: '', date: ''});
+    setFormMode('create');
+  }, []);
+
+  const openEdit = useCallback((row: EventRow) => {
+    setValues({name: row.name, date: row.date});
+    setFormMode({edit: row});
+  }, []);
+
+  const openManage = useCallback((row: EventRow) => setManaging(row), []);
+
+  const openDelete = useCallback((row: EventRow) => {
+    setDependents(undefined);
+    setDeleteTarget(row);
+  }, []);
+
+  const handleFieldChange = useCallback((name: string, value: FieldValue) => {
+    setValues((prev) => ({...prev, [name]: value}));
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const name = String(values.name ?? '');
+    const date = String(values.date ?? '');
+    if (formMode === 'create') {
+      createMutation.mutate({name, date});
+    } else if (formMode && 'edit' in formMode) {
+      updateMutation.mutate({id: formMode.edit.id, name, date});
+    }
+  }, [values, formMode, createMutation, updateMutation]);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+  }, [deleteTarget, deleteMutation]);
+
+  const actions = useCallback(
+    (): RowAction<EventRow>[] => [
+      {label: 'Edit', onClick: openEdit},
+      {label: 'Manage beers', onClick: openManage},
+      {label: 'Delete', onClick: openDelete, variant: 'danger'},
+    ],
+    [openEdit, openManage, openDelete],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-2xl font-bold text-gold">Events</h1>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-check-fg"
+        >
+          New event
+        </button>
+      </div>
+
+      {events.isLoading ? (
+        <p className="text-sm text-text-secondary">Loading events…</p>
+      ) : events.isError ? (
+        <p className="text-sm text-red">Failed to load events.</p>
+      ) : (
+        <DataTable
+          columns={eventColumns}
+          rows={events.data ?? []}
+          getRowId={(row) => row.id}
+          actions={actions}
+          filterPlaceholder="Filter events…"
+          emptyMessage="No events yet."
+        />
+      )}
+
+      {formMode ? (
+        <EntityForm
+          fields={eventFields}
+          values={values}
+          onChange={handleFieldChange}
+          onSubmit={handleSubmit}
+          onCancel={() => setFormMode(null)}
+          submitLabel={formMode === 'create' ? 'Create' : 'Save'}
+        />
+      ) : null}
+
+      <ConfirmDelete
+        open={deleteTarget !== null}
+        title="Delete this event?"
+        dependents={dependents}
+        confirming={deleteMutation.isPending}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => {
+          setDeleteTarget(null);
+          setDependents(undefined);
+        }}
+      />
+
+      {managing ? (
+        <BeerManager event={managing} onClose={() => setManaging(null)} />
+      ) : null}
+    </div>
+  );
+}
+
+const linkedColumns: Column<AdminBeer>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
+  {id: 'brewery', header: 'Brewery', accessor: (row) => row.brewery.name},
+  {id: 'style', header: 'Style', accessor: (row) => row.style.name},
+];
+
+type BeerManagerProps = {
+  event: EventRow;
+  onClose: () => void;
+};
+
+function BeerManager({event, onClose}: BeerManagerProps) {
+  const queryClient = useQueryClient();
+  const linkedKey = useMemo(() => ['admin', 'events', event.id, 'beers'], [event.id]);
+
+  const linked = useQuery({
+    queryKey: linkedKey,
+    queryFn: () => listBeersForEvent({data: {eventId: event.id}}),
+  });
+  const allBeers = useQuery({queryKey: ['admin', 'beers'], queryFn: () => listBeers()});
+
+  const [pickerQuery, setPickerQuery] = useState('');
+
+  const invalidateLinked = useCallback(
+    () => queryClient.invalidateQueries({queryKey: linkedKey}),
+    [queryClient, linkedKey],
+  );
+
+  const addMutation = useMutation({
+    mutationFn: (beerId: number) => addBeerToEvent({data: {eventId: event.id, beerId}}),
+    onSuccess: invalidateLinked,
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (beerId: number) =>
+      removeBeerFromEvent({data: {eventId: event.id, beerId}}),
+    onSuccess: invalidateLinked,
+  });
+
+  const linkedIds = useMemo(
+    () => new Set((linked.data ?? []).map((beer) => beer.id)),
+    [linked.data],
+  );
+
+  const pickerResults = useMemo(
+    () => filterRows(allBeers.data ?? [], pickerColumns, pickerQuery).slice(0, 25),
+    [allBeers.data, pickerQuery],
+  );
+
+  const handleRemove = useCallback(
+    (row: AdminBeer) => removeMutation.mutate(row.id),
+    [removeMutation],
+  );
+
+  const linkedActions = useCallback(
+    (): RowAction<AdminBeer>[] => [
+      {label: 'Remove', onClick: handleRemove, variant: 'danger'},
+    ],
+    [handleRemove],
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="flex max-h-[85vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl border border-border bg-surface p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-lg font-bold text-text">
+            Beers — {event.name}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text-secondary hover:text-text"
+          >
+            Close
+          </button>
+        </div>
+
+        <section className="flex flex-col gap-2">
+          <h3 className="text-sm font-semibold text-text-secondary">Linked beers</h3>
+          {linked.isLoading ? (
+            <p className="text-sm text-text-secondary">Loading…</p>
+          ) : linked.isError ? (
+            <p className="text-sm text-red">Failed to load linked beers.</p>
+          ) : (
+            <DataTable
+              columns={linkedColumns}
+              rows={linked.data ?? []}
+              getRowId={(row) => row.id}
+              actions={linkedActions}
+              filterPlaceholder="Filter linked beers…"
+              emptyMessage="No beers linked to this event yet."
+            />
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2">
+          <h3 className="text-sm font-semibold text-text-secondary">Add a beer</h3>
+          <input
+            type="text"
+            value={pickerQuery}
+            onChange={(e) => setPickerQuery(e.target.value)}
+            placeholder="Search beers by name…"
+            className="w-full max-w-xs rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-muted"
+          />
+          {allBeers.isLoading ? (
+            <p className="text-sm text-text-secondary">Loading beers…</p>
+          ) : allBeers.isError ? (
+            <p className="text-sm text-red">Failed to load beers.</p>
+          ) : (
+            <ul className="flex flex-col divide-y divide-border-light rounded-lg border border-border">
+              {pickerResults.map((beer) => {
+                const isLinked = linkedIds.has(beer.id);
+                return (
+                  <li
+                    key={beer.id}
+                    className="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+                  >
+                    <span className="text-text">
+                      {beer.name}
+                      <span className="text-text-muted"> · {beer.brewery.name}</span>
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => addMutation.mutate(beer.id)}
+                      disabled={isLinked}
+                      className="rounded-md px-2 py-1 text-xs font-medium text-gold hover:underline disabled:text-text-muted disabled:no-underline"
+                    >
+                      {isLinked ? 'Added' : 'Add'}
+                    </button>
+                  </li>
+                );
+              })}
+              {pickerResults.length === 0 ? (
+                <li className="px-3 py-2 text-sm text-text-secondary">No matches.</li>
+              ) : null}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+const pickerColumns: Column<AdminBeer>[] = [
+  {id: 'name', header: 'Name', accessor: (row) => row.name},
+];

--- a/apps/www/src/routes/admin/events.tsx
+++ b/apps/www/src/routes/admin/events.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useId, useMemo, useState} from 'react';
 import {createFileRoute} from '@tanstack/react-router';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
@@ -249,6 +249,7 @@ type BeerManagerProps = {
 };
 
 function BeerManager({event, onClose}: BeerManagerProps) {
+  const titleId = useId();
   const queryClient = useQueryClient();
   const linkedKey = useMemo(() => ['admin', 'events', event.id, 'beers'], [event.id]);
 
@@ -304,13 +305,14 @@ function BeerManager({event, onClose}: BeerManagerProps) {
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby={titleId}
     >
       <div
         className="flex max-h-[85vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl border border-border bg-surface p-6 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
-          <h2 className="font-display text-lg font-bold text-text">
+          <h2 id={titleId} className="font-display text-lg font-bold text-text">
             Beers — {event.name}
           </h2>
           <button

--- a/apps/www/tests/lib/admin/events.test.ts
+++ b/apps/www/tests/lib/admin/events.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'bun:test';
+
+import {parseDeleteResponse} from '../../../src/lib/admin/events';
+
+describe('parseDeleteResponse', function () {
+  it('should return ok when the status is 200', function () {
+    expect(parseDeleteResponse(200, {ok: true})).toEqual({ok: true});
+  });
+
+  it('should return ok when the status is 204 with no body', function () {
+    expect(parseDeleteResponse(204, null)).toEqual({ok: true});
+  });
+
+  it('should surface dependents from a 409 body', function () {
+    const result = parseDeleteResponse(409, {
+      error: 'has dependents',
+      dependents: {eventLinks: 2},
+    });
+
+    expect(result).toEqual({ok: false, dependents: {eventLinks: 2}});
+  });
+
+  it('should fall back to empty dependents for a malformed 409 body', function () {
+    expect(parseDeleteResponse(409, 'oops')).toEqual({ok: false, dependents: {}});
+  });
+
+  it('should fall back to empty dependents for an empty 409 body', function () {
+    expect(parseDeleteResponse(409, null)).toEqual({ok: false, dependents: {}});
+  });
+});

--- a/apps/www/tests/lib/admin/events.test.ts
+++ b/apps/www/tests/lib/admin/events.test.ts
@@ -27,4 +27,10 @@ describe('parseDeleteResponse', function () {
   it('should fall back to empty dependents for an empty 409 body', function () {
     expect(parseDeleteResponse(409, null)).toEqual({ok: false, dependents: {}});
   });
+
+  it('should throw on a non-409 error status rather than masking it', function () {
+    expect(() => parseDeleteResponse(500, {error: 'boom'})).toThrow(
+      'Delete failed: 500',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds the first www admin entity page: `/admin/events`.

- **Events CRUD** — a `DataTable` (Name, Date) with client filter, create/edit via `EntityForm`, and safe-delete via `ConfirmDelete`.
- **Per-event beer manager** — an in-page modal panel listing the event's linked beers (with per-row Remove) plus a searchable picker to add beers from the full catalog. Add is idempotent; already-linked beers are marked "Added".
- **Server functions** (`lib/admin/events.ts`) — each call is a `createServerFn` wrapping `adminFetch`, keeping `ADMIN_API_KEY` server-only.

### The 409 decision
`adminFetch` throws on every non-2xx and only embeds the body as a string, so the structured `dependents` payload from a blocked delete is unrecoverable through it. `deleteEvent` therefore uses a **raw fetch** (replicating the env resolution inline) and a pure, unit-tested `parseDeleteResponse(status, body)` helper that maps the response to a `{ok:true} | {ok:false; dependents}` union. All other calls use `adminFetch` normally. `server-fn.ts` and the shared primitives are untouched.

## Testing
- `bun run typecheck` — clean across all packages.
- `bun test` — 107 pass (incl. 5 new `parseDeleteResponse` cases: 200/204 → ok, 409 with dependents, malformed/empty 409 body → `{ok:false, dependents:{}}`).

## Notes
- `routeTree.gen.ts` is gitignored (generated by the `tanstackStart()` vite plugin), so it is not in this diff — regenerate via `bun run dev:www` / build.
- Date is entered as a free text string (`YYYY-MM-DD`), matching the API's `min(1)` contract — `EntityForm` has no native `date` field type and adding one is out of scope.
- No edits to `apps/api/**`, `@domain`, `NAV_ITEMS`, `server-fn.ts`, or the shared primitives.