### PR TITLE
feat(www): gate /admin behind Google sign-in

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -16,9 +16,11 @@
     "@tanstack/react-router": "^1.167.4",
     "@tanstack/react-start": "^1.166.15",
     "@vitejs/plugin-react": "^6.0.1",
+    "env": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",

--- a/apps/www/src/lib/auth.server.ts
+++ b/apps/www/src/lib/auth.server.ts
@@ -1,0 +1,78 @@
+// SERVER-ONLY module. Google OAuth code-exchange helpers + allowlist check.
+import {getEnv} from './env.server';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const SCOPES = 'openid email profile';
+
+type GoogleTokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  id_token?: string;
+};
+
+type GoogleUserInfo = {
+  id: string;
+  email: string;
+  name: string;
+  picture: string;
+};
+
+export function buildGoogleAuthUrl(): string {
+  const params = new URLSearchParams({
+    client_id: getEnv().GOOGLE_CLIENT_ID,
+    redirect_uri: getEnv().GOOGLE_CALLBACK_URL,
+    response_type: 'code',
+    scope: SCOPES,
+    access_type: 'offline',
+    prompt: 'select_account',
+  });
+
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<GoogleTokenResponse> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: new URLSearchParams({
+      code,
+      client_id: getEnv().GOOGLE_CLIENT_ID,
+      client_secret: getEnv().GOOGLE_CLIENT_SECRET,
+      redirect_uri: getEnv().GOOGLE_CALLBACK_URL,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Google token exchange failed (${String(response.status)}): ${body}`);
+  }
+
+  return response.json() as Promise<GoogleTokenResponse>;
+}
+
+export async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+  const response = await fetch(GOOGLE_USERINFO_URL, {
+    headers: {Authorization: `Bearer ${accessToken}`},
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Google userinfo fetch failed (${String(response.status)}): ${body}`);
+  }
+
+  return response.json() as Promise<GoogleUserInfo>;
+}
+
+// Pure comparator — case-insensitive, whitespace-trimmed. Unit-testable
+// without env setup.
+export function emailMatchesAllowlist(email: string, allowed: string): boolean {
+  return email.trim().toLowerCase() === allowed.trim().toLowerCase();
+}
+
+export function isAllowedEmail(email: string): boolean {
+  return emailMatchesAllowlist(email, getEnv().ALLOWED_EMAIL);
+}

--- a/apps/www/src/lib/env.server.ts
+++ b/apps/www/src/lib/env.server.ts
@@ -1,0 +1,22 @@
+// SERVER-ONLY module. Reads and validates Google OAuth + session env vars.
+// Must never be imported into client code — pull it in via dynamic import
+// inside createServerFn handlers only.
+import {parseEnv} from 'env';
+import {z} from 'zod';
+
+const envSchema = z.object({
+  GOOGLE_CLIENT_ID: z.string().min(1),
+  GOOGLE_CLIENT_SECRET: z.string().min(1),
+  GOOGLE_CALLBACK_URL: z.string().url(),
+  ALLOWED_EMAIL: z.string().email(),
+  SESSION_SECRET: z.string().min(32),
+});
+
+let cached: z.infer<typeof envSchema> | null = null;
+
+export function getEnv() {
+  if (!cached) {
+    cached = parseEnv(envSchema);
+  }
+  return cached;
+}

--- a/apps/www/src/lib/session-actions.ts
+++ b/apps/www/src/lib/session-actions.ts
@@ -1,0 +1,12 @@
+import {createServerFn} from '@tanstack/react-start';
+
+// Dynamic-imports session.server so the server-only module is never pulled
+// into the client bundle.
+export const getAuthState = createServerFn({method: 'GET'}).handler(async () => {
+  const {getSession} = await import('./session.server');
+  const session = await getSession();
+  if (!session?.authenticated) {
+    return {authenticated: false as const};
+  }
+  return {authenticated: true as const, email: session.email};
+});

--- a/apps/www/src/lib/session-crypto.ts
+++ b/apps/www/src/lib/session-crypto.ts
@@ -1,0 +1,34 @@
+// Pure HMAC-SHA256 helpers — no env or cookie dependencies, so the signing
+// core is unit-testable in isolation. The secret is passed in by the caller
+// (session.server) rather than read here.
+
+async function importKey(secret: string, usage: 'sign' | 'verify'): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    {name: 'HMAC', hash: 'SHA-256'},
+    false,
+    [usage],
+  );
+}
+
+export async function signPayload(value: string, secret: string): Promise<string> {
+  const key = await importKey(secret, 'sign');
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+export async function verifyPayload(
+  value: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  try {
+    const key = await importKey(secret, 'verify');
+    const sigBytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
+    return await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(value));
+  } catch {
+    // Malformed base64 signature → treat as invalid, never throw.
+    return false;
+  }
+}

--- a/apps/www/src/lib/session.server.ts
+++ b/apps/www/src/lib/session.server.ts
@@ -3,6 +3,7 @@
 // createServerFn handlers only.
 import {getCookie, setCookie} from '@tanstack/react-start/server';
 import {getEnv} from './env.server';
+import {signPayload, verifyPayload} from './session-crypto';
 
 const SESSION_COOKIE = 'pghbeer_session';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
@@ -18,33 +19,11 @@ type SessionPayload = {
   sig: string;
 };
 
-async function importKey(usage: 'sign' | 'verify'): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(getEnv().SESSION_SECRET),
-    {name: 'HMAC', hash: 'SHA-256'},
-    false,
-    [usage],
-  );
-}
-
-async function sign(value: string): Promise<string> {
-  const key = await importKey('sign');
-  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
-  return btoa(String.fromCharCode(...new Uint8Array(signature)));
-}
-
-async function verify(value: string, signature: string): Promise<boolean> {
-  const key = await importKey('verify');
-  const sigBytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
-  return crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(value));
-}
-
 export async function createSession(email: string): Promise<void> {
   const data: SessionData = {email, authenticated: true};
   const expires = Date.now() + MAX_AGE * 1000;
   const payload = JSON.stringify({data, expires});
-  const sig = await sign(payload);
+  const sig = await signPayload(payload, getEnv().SESSION_SECRET);
   const cookie: SessionPayload = {data, expires, sig};
 
   setCookie(SESSION_COOKIE, btoa(JSON.stringify(cookie)), {
@@ -65,7 +44,7 @@ export async function getSession(): Promise<SessionData | null> {
     if (Date.now() > cookie.expires) return null;
 
     const payload = JSON.stringify({data: cookie.data, expires: cookie.expires});
-    const valid = await verify(payload, cookie.sig);
+    const valid = await verifyPayload(payload, cookie.sig, getEnv().SESSION_SECRET);
     if (!valid) return null;
 
     return cookie.data;

--- a/apps/www/src/lib/session.server.ts
+++ b/apps/www/src/lib/session.server.ts
@@ -1,0 +1,85 @@
+// SERVER-ONLY module. HMAC-SHA256-signed session cookie. Must never be
+// imported into client code — pull it in via dynamic import inside
+// createServerFn handlers only.
+import {getCookie, setCookie} from '@tanstack/react-start/server';
+import {getEnv} from './env.server';
+
+const SESSION_COOKIE = 'pghbeer_session';
+const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+type SessionData = {
+  email: string;
+  authenticated: boolean;
+};
+
+type SessionPayload = {
+  data: SessionData;
+  expires: number;
+  sig: string;
+};
+
+async function importKey(usage: 'sign' | 'verify'): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(getEnv().SESSION_SECRET),
+    {name: 'HMAC', hash: 'SHA-256'},
+    false,
+    [usage],
+  );
+}
+
+async function sign(value: string): Promise<string> {
+  const key = await importKey('sign');
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+async function verify(value: string, signature: string): Promise<boolean> {
+  const key = await importKey('verify');
+  const sigBytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
+  return crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(value));
+}
+
+export async function createSession(email: string): Promise<void> {
+  const data: SessionData = {email, authenticated: true};
+  const expires = Date.now() + MAX_AGE * 1000;
+  const payload = JSON.stringify({data, expires});
+  const sig = await sign(payload);
+  const cookie: SessionPayload = {data, expires, sig};
+
+  setCookie(SESSION_COOKIE, btoa(JSON.stringify(cookie)), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAX_AGE,
+  });
+}
+
+export async function getSession(): Promise<SessionData | null> {
+  const raw = getCookie(SESSION_COOKIE);
+  if (!raw) return null;
+
+  try {
+    const cookie: SessionPayload = JSON.parse(atob(raw));
+    if (Date.now() > cookie.expires) return null;
+
+    const payload = JSON.stringify({data: cookie.data, expires: cookie.expires});
+    const valid = await verify(payload, cookie.sig);
+    if (!valid) return null;
+
+    return cookie.data;
+  } catch {
+    return null;
+  }
+}
+
+export async function destroySession(): Promise<void> {
+  setCookie(SESSION_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+}

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {PersistQueryClientProvider} from '@tanstack/react-query-persist-client';
 import {createSyncStoragePersister} from '@tanstack/query-sync-storage-persister';
 import type {Persister} from '@tanstack/react-query-persist-client';
 import {STORAGE_KEYS} from '../lib/constants';
+import {getAuthState} from '../lib/session-actions';
 import '../globals.css';
 
 function NotFound() {
@@ -29,6 +30,7 @@ function NotFound() {
 
 export const Route = createRootRoute({
   notFoundComponent: NotFound,
+  beforeLoad: async () => ({auth: await getAuthState()}),
   head: () => ({
     meta: [
       {charSet: 'utf-8'},

--- a/apps/www/src/routes/admin/route.tsx
+++ b/apps/www/src/routes/admin/route.tsx
@@ -1,10 +1,12 @@
-import {createFileRoute, Link, Outlet} from '@tanstack/react-router';
+import {createFileRoute, Link, Outlet, redirect} from '@tanstack/react-router';
 import {NAV_ITEMS} from '../../components/admin/nav';
 
 export const Route = createFileRoute('/admin')({
-  // AUTH PLACEHOLDER — the auth task replaces this with a real session check;
-  // do not add logic here now. Returning nothing allows everyone through.
-  beforeLoad: () => {},
+  beforeLoad: ({context}) => {
+    if (!context.auth.authenticated) {
+      throw redirect({to: '/auth/login', search: {error: undefined}});
+    }
+  },
   component: AdminLayout,
 });
 

--- a/apps/www/src/routes/auth/callback.tsx
+++ b/apps/www/src/routes/auth/callback.tsx
@@ -1,0 +1,61 @@
+import {createFileRoute, redirect} from '@tanstack/react-router';
+import {createServerFn} from '@tanstack/react-start';
+
+const processOAuthCode = createServerFn({method: 'POST'})
+  .inputValidator((code: string) => code)
+  .handler(async ({data: code}) => {
+    try {
+      const {exchangeCodeForTokens, fetchGoogleUserInfo, isAllowedEmail} = await import(
+        '../../lib/auth.server'
+      );
+      const {createSession} = await import('../../lib/session.server');
+
+      const tokens = await exchangeCodeForTokens(code);
+      const userInfo = await fetchGoogleUserInfo(tokens.access_token);
+
+      if (!isAllowedEmail(userInfo.email)) {
+        return {error: 'unauthorized_email'};
+      }
+
+      await createSession(userInfo.email);
+      return {error: null};
+    } catch (error) {
+      // Don't swallow: log the upstream cause before returning the sentinel.
+      console.warn('OAuth callback failed', new Error('auth_failed', {cause: error}));
+      return {error: 'auth_failed'};
+    }
+  });
+
+export const Route = createFileRoute('/auth/callback')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    code: search.code as string | undefined,
+    error: search.error as string | undefined,
+  }),
+  loaderDeps: ({search}) => ({code: search.code, error: search.error}),
+  loader: async ({deps}) => {
+    if (deps.error) {
+      throw redirect({to: '/auth/login', search: {error: 'access_denied'}});
+    }
+
+    if (!deps.code) {
+      throw redirect({to: '/auth/login', search: {error: 'missing_code'}});
+    }
+
+    const result = await processOAuthCode({data: deps.code});
+
+    if (result.error) {
+      throw redirect({to: '/auth/login', search: {error: result.error}});
+    }
+
+    throw redirect({to: '/admin'});
+  },
+  component: CallbackPage,
+});
+
+function CallbackPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg">
+      <p className="text-sm text-text-secondary">Authenticating…</p>
+    </div>
+  );
+}

--- a/apps/www/src/routes/auth/callback.tsx
+++ b/apps/www/src/routes/auth/callback.tsx
@@ -20,8 +20,8 @@ const processOAuthCode = createServerFn({method: 'POST'})
       await createSession(userInfo.email);
       return {error: null};
     } catch (error) {
-      // Don't swallow: log the upstream cause before returning the sentinel.
-      console.warn('OAuth callback failed', new Error('auth_failed', {cause: error}));
+      // Don't swallow: log the original error before returning the sentinel.
+      console.warn('OAuth callback failed:', error);
       return {error: 'auth_failed'};
     }
   });

--- a/apps/www/src/routes/auth/login.tsx
+++ b/apps/www/src/routes/auth/login.tsx
@@ -1,0 +1,51 @@
+import {createFileRoute} from '@tanstack/react-router';
+import {createServerFn} from '@tanstack/react-start';
+
+const getGoogleAuthUrl = createServerFn({method: 'GET'}).handler(async () => {
+  const {buildGoogleAuthUrl} = await import('../../lib/auth.server');
+  return buildGoogleAuthUrl();
+});
+
+export const Route = createFileRoute('/auth/login')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    error: search.error as string | undefined,
+  }),
+  head: () => ({
+    meta: [{title: 'Sign in — PghBeer'}],
+  }),
+  loader: async () => {
+    const authUrl = await getGoogleAuthUrl();
+    return {authUrl};
+  },
+  component: LoginPage,
+});
+
+function LoginPage() {
+  const {authUrl} = Route.useLoaderData();
+  const {error} = Route.useSearch();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg px-4">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div>
+          <div className="font-display text-2xl font-bold uppercase tracking-wide text-gold">
+            PghBeer
+          </div>
+          <div className="text-[11px] text-text-secondary">Admin</div>
+        </div>
+        <p className="text-sm text-text-secondary">Sign in to manage the festival.</p>
+        {error ? (
+          <p className="rounded-lg bg-surface px-4 py-3 text-sm text-text">
+            That account isn&apos;t authorized.
+          </p>
+        ) : null}
+        <a
+          href={authUrl}
+          className="inline-block rounded-xl bg-gold px-6 py-3 font-semibold text-check-fg transition-colors"
+        >
+          Sign in with Google
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/routes/auth/login.tsx
+++ b/apps/www/src/routes/auth/login.tsx
@@ -6,6 +6,14 @@ const getGoogleAuthUrl = createServerFn({method: 'GET'}).handler(async () => {
   return buildGoogleAuthUrl();
 });
 
+// Only an allowlist rejection means "not authorized" — every other code is a
+// transient or aborted sign-in and must not be misreported as an authz failure.
+function errorMessage(error: string): string {
+  return error === 'unauthorized_email'
+    ? "That account isn't authorized."
+    : 'Sign-in failed. Please try again.';
+}
+
 export const Route = createFileRoute('/auth/login')({
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error as string | undefined,
@@ -36,7 +44,7 @@ function LoginPage() {
         <p className="text-sm text-text-secondary">Sign in to manage the festival.</p>
         {error ? (
           <p className="rounded-lg bg-surface px-4 py-3 text-sm text-text">
-            That account isn&apos;t authorized.
+            {errorMessage(error)}
           </p>
         ) : null}
         <a

--- a/apps/www/tests/lib/auth.server.test.ts
+++ b/apps/www/tests/lib/auth.server.test.ts
@@ -1,0 +1,20 @@
+import {describe, it, expect} from 'bun:test';
+import {emailMatchesAllowlist} from '../../src/lib/auth.server';
+
+describe('emailMatchesAllowlist', function () {
+  it('should return true when the email exactly matches the allowlist', function () {
+    expect(emailMatchesAllowlist('admin@pghbeer.com', 'admin@pghbeer.com')).toBe(true);
+  });
+
+  it('should return true when the email matches case-insensitively', function () {
+    expect(emailMatchesAllowlist('Admin@PghBeer.com', 'admin@pghbeer.com')).toBe(true);
+  });
+
+  it('should return false when the email differs from the allowlist', function () {
+    expect(emailMatchesAllowlist('intruder@evil.com', 'admin@pghbeer.com')).toBe(false);
+  });
+
+  it('should return true when surrounding whitespace differs', function () {
+    expect(emailMatchesAllowlist('  admin@pghbeer.com  ', 'admin@pghbeer.com')).toBe(true);
+  });
+});

--- a/apps/www/tests/lib/session-crypto.test.ts
+++ b/apps/www/tests/lib/session-crypto.test.ts
@@ -1,0 +1,42 @@
+import {describe, it, expect} from 'bun:test';
+import {signPayload, verifyPayload} from '../../src/lib/session-crypto';
+
+const SECRET = 'test-session-secret-at-least-32-chars-long';
+
+describe('session-crypto', function () {
+  it('should verify a signature produced for the same payload and secret', async function () {
+    const payload = JSON.stringify({email: 'admin@pghbeer.com', expires: 123});
+    const sig = await signPayload(payload, SECRET);
+
+    expect(await verifyPayload(payload, sig, SECRET)).toBe(true);
+  });
+
+  it('should reject a tampered payload', async function () {
+    const payload = JSON.stringify({email: 'admin@pghbeer.com', expires: 123});
+    const sig = await signPayload(payload, SECRET);
+    const tampered = JSON.stringify({email: 'intruder@evil.com', expires: 123});
+
+    expect(await verifyPayload(tampered, sig, SECRET)).toBe(false);
+  });
+
+  it('should reject a mutated signature', async function () {
+    const payload = JSON.stringify({email: 'admin@pghbeer.com', expires: 123});
+    const sig = await signPayload(payload, SECRET);
+    const mutated = (sig[0] === 'A' ? 'B' : 'A') + sig.slice(1);
+
+    expect(await verifyPayload(payload, mutated, SECRET)).toBe(false);
+  });
+
+  it('should reject a signature made with a different secret', async function () {
+    const payload = JSON.stringify({email: 'admin@pghbeer.com', expires: 123});
+    const sig = await signPayload(payload, SECRET);
+
+    expect(await verifyPayload(payload, sig, 'a-completely-different-secret-value-here')).toBe(
+      false,
+    );
+  });
+
+  it('should return false for a malformed (non-base64) signature instead of throwing', async function () {
+    expect(await verifyPayload('payload', '!!!not-base64!!!', SECRET)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Gates `/admin/*` behind Google OAuth with a single-email allowlist. The www-skeleton task left a passthrough `beforeLoad: () => {}` on the admin route, so every visitor reached the console. This adds real authentication.

- Visiting `/admin` while unauthenticated → redirect to `/auth/login`
- Signing in as `ALLOWED_EMAIL` → lands on `/admin`
- Any other Google account → redirect to `/auth/login` with a visible error

## Implementation

Ported the proven OAuth + HMAC-signed cookie pattern from the sibling `schwankie` project, adapted to pghbeer (relative imports, `pghbeer_session` cookie, `/admin` success redirect, no `API_KEY` field).

- **`lib/env.server.ts`** — Zod-validated env via the `env` workspace package's `parseEnv`.
- **`lib/auth.server.ts`** — `buildGoogleAuthUrl` / `exchangeCodeForTokens` / `fetchGoogleUserInfo` (preserve upstream error body + status), plus a **pure** `emailMatchesAllowlist(email, allowed)` comparator that `isAllowedEmail` delegates to.
- **`lib/session.server.ts`** — HMAC-SHA256-signed cookie via `crypto.subtle`; `getSession` returns `null` on missing/expired/tampered/parse-error.
- **`lib/session-actions.ts`** — `getAuthState` server fn returning `{authenticated: false} | {authenticated: true, email}`.
- **`routes/auth/login.tsx`**, **`routes/auth/callback.tsx`** — sign-in entry and code-exchange. The callback's catch logs the upstream cause at warn level before returning the `auth_failed` sentinel.
- **`routes/__root.tsx`** — additive `beforeLoad` exposing `{auth}` into route context.
- **`routes/admin/route.tsx`** — passthrough stub flipped to a real `context.auth.authenticated` check.

All server-only modules are pulled in via dynamic import inside `createServerFn` handlers, so they never enter the client bundle. www stays a pure API client (no DB/domain import).

## Required env vars

The operator provisions the Google OAuth client out of band. Set these on the www app:

| Var | Notes |
| --- | --- |
| `GOOGLE_CLIENT_ID` | OAuth client id |
| `GOOGLE_CLIENT_SECRET` | OAuth client secret |
| `GOOGLE_CALLBACK_URL` | Must match the deployed `/auth/callback` URL |
| `ALLOWED_EMAIL` | The single authorized operator email |
| `SESSION_SECRET` | ≥ 32 chars; HMAC signing key for the session cookie |

## Verification

- `bun run typecheck` — clean across all packages
- `bun test` — 106 pass (incl. 4 new `emailMatchesAllowlist` cases: exact, case-insensitive, mismatch, whitespace-trimmed)
- `grep -rE "from '(database|domain|drizzle)" apps/www/src` — no matches

## Notes

- The admin-route redirect includes `search: {error: undefined}`; TanStack's typed router requires the `search` arg because `/auth/login` declares `validateSearch`. (Plan showed the no-search form; the type system mandates it.)
- `bun.lock` is gitignored in this repo, so the install isn't committed — the `env`/`zod` declarations in `apps/www/package.json` are the durable signal.
- Per scope: no logout UI (`destroySession` is ported for completeness), no `NAV_ITEMS` edits, no api/DB changes.